### PR TITLE
karpenter(gcp): set CLUSTER_LOCATION env on the controller

### DIFF
--- a/pulumi/src/components/k8s/karpenter.ts
+++ b/pulumi/src/components/k8s/karpenter.ts
@@ -257,7 +257,13 @@ export class Karpenter extends pulumi.ComponentResource {
               clusterName: args.clusterName,
               clusterEndpoint: args.clusterEndpoint,
             },
-            ...(addBootstrap ? { 
+            // The published controller image behind the floating :v0.0.1 tag is karpenter v1.7.0,
+            // which requires the CLUSTER_LOCATION env var (the chart only renders LOCATION). Without
+            // it the controller panics on startup ("missing required ... CLUSTER_LOCATION").
+            env: [
+              { name: "CLUSTER_LOCATION", value: args.location },
+            ],
+            ...(addBootstrap ? {
               tolerations: [
                 { key: "components.gke.io/gke-managed-components", operator: "Exists", effect: "NoSchedule" },
                 { key: "node.kubernetes.io/not-ready", operator: "Exists", effect: "NoExecute", tolerationSeconds: 300 },


### PR DESCRIPTION
The karpenter component pins a chart gitRef, but the controller image is the **floating** tag `public.ecr.aws/cloudpilotai/gcp/karpenter:v0.0.1`, which was repushed to karpenter **v1.7.0**. That version renamed the cluster-zone env var `LOCATION` → `CLUSTER_LOCATION`, but the chart at the pinned ref only renders `LOCATION`.

**Symptom:** a *fresh* controller panics on startup (`validating options, missing required flag cluster-location or env var CLUSTER_LOCATION`) and CrashLoopBackOffs → no nodes get provisioned. Existing clusters only work because their live Deployments were hot-patched (drift not in IaC).

**Fix:** set `controller.env` `CLUSTER_LOCATION = args.location` so a fresh deploy comes up clean and the drift is captured in IaC.

Found while standing up new GKE clusters for geo-distributed mainnet tool-nodes.