### PR TITLE
fix(aws): three live-blocking hosted-CP / k0smotron admission fixes

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -228,7 +228,18 @@ export function emitAwsClusterCr(
       // to a key pair literally named "default" (which won't exist), failing
       // every instance launch. "" means "no SSH key pair".
       sshKeyName: opts.sshKeyName ?? "",
-      controlPlaneLoadBalancer: {
+      // With loadBalancerType DISABLED (hosted-CP workload clusters: k0smotron
+      // exposes the API from the mgmt cluster) CAPA's validation webhook
+      // REJECTS listener/ingress sub-fields — live-observed:
+      // 'spec.controlPlaneLoadBalancer.additionalListeners: Invalid value'
+      // denied the whole AWSCluster, so the VPC was never created. Emit the
+      // bare type and nothing else in that case; the konnectivity listener +
+      // rules below apply only to the standalone-CP NLB path.
+      controlPlaneLoadBalancer:
+        opts.loadBalancerType ===
+        AwsClusterV1Beta2SpecControlPlaneLoadBalancerLoadBalancerType.DISABLED
+          ? { loadBalancerType: opts.loadBalancerType }
+          : {
         loadBalancerType: opts.loadBalancerType,
         ...(opts.loadBalancerScheme
           ? { scheme: opts.loadBalancerScheme }

--- a/packages/nebula/src/modules/infra/aws/cluster.ts
+++ b/packages/nebula/src/modules/infra/aws/cluster.ts
@@ -17,7 +17,7 @@ import {
   K0SmotronControlPlaneSpecPersistence,
   K0SmotronControlPlaneSpecPersistencePersistentVolumeClaimSpecResourcesRequests,
 } from "#imports/controlplane.cluster.x-k8s.io";
-import { K0sWorkerConfigTemplate } from "#imports/bootstrap.cluster.x-k8s.io";
+import { K0sWorkerConfigTemplateV1Beta2 } from "#imports/bootstrap.cluster.x-k8s.io";
 import { AwsClusterV1Beta2SpecControlPlaneLoadBalancerLoadBalancerType } from "#imports/infrastructure.cluster.x-k8s.io";
 
 export interface AwsWorkloadClusterWorkers {
@@ -355,14 +355,20 @@ export class AwsWorkloadCluster extends BaseConstruct<AwsWorkloadClusterConfig> 
       }
       k0sWorkerArgs.push(...(pool.k0sArgs ?? []));
 
-      new K0sWorkerConfigTemplate(this, `worker-config${opts.idSuffix}`, {
+      // v1beta2 REQUIRED: k0smotron's v1beta2 storage schema renamed
+      // preStartCommands -> preK0sCommands and declares no conversion for the
+      // old field — applying the v1beta1 shape fails server-side apply with
+      // '.spec.template.spec.preStartCommands: field not declared in schema'
+      // (live-observed: all worker bootstrap templates rejected, workers never
+      // provisioned).
+      new K0sWorkerConfigTemplateV1Beta2(this, `worker-config${opts.idSuffix}`, {
         metadata: { name: opts.workerConfigName, namespace },
         spec: {
           template: {
             spec: {
               version: k0sWorkerVersion,
               ...(k0sWorkerArgs.length ? { args: k0sWorkerArgs } : {}),
-              preStartCommands: [
+              preK0SCommands: [
                 ...DEFAULT_PRESTART_COMMANDS,
                 ...(pool.extraPreStartCommands ?? []),
               ],
@@ -388,7 +394,7 @@ export class AwsWorkloadCluster extends BaseConstruct<AwsWorkloadClusterConfig> 
                 : {}),
               bootstrap: {
                 configRef: {
-                  apiVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+                  apiVersion: "bootstrap.cluster.x-k8s.io/v1beta2",
                   kind: "K0sWorkerConfigTemplate",
                   name: opts.workerConfigName,
                 },

--- a/packages/nebula/src/modules/infra/aws/cluster.ts
+++ b/packages/nebula/src/modules/infra/aws/cluster.ts
@@ -260,7 +260,26 @@ export class AwsWorkloadCluster extends BaseConstruct<AwsWorkloadClusterConfig> 
           }
         : { type: "emptyDir" };
     new K0smotronControlPlane(this, "control-plane", {
-      metadata: { name: controlPlaneName, namespace },
+      metadata: {
+        name: controlPlaneName,
+        namespace,
+        // k0smotron v2.x dropped spec.service.{annotations,labels,...} from its
+        // internal v1beta2 API; the controller reads Service annotations ONLY
+        // from this JSON-encoded CR annotation (see k0smotron
+        // api/k0smotron.io/v1beta1/k0smotroncluster_service_annotations.go and
+        // the Service builder's GetServiceAnnotations(kmc.Annotations)). The
+        // spec field below is kept for forward-compat, but without this
+        // annotation the LB Service renders with NO annotations — e.g. an AWS
+        // NLB silently defaults to scheme "internal".
+        ...(this.config.controlPlaneServiceAnnotations
+          ? {
+              annotations: {
+                "k0smotron.io/conversion-dropped-service.annotations":
+                  JSON.stringify(this.config.controlPlaneServiceAnnotations),
+              },
+            }
+          : {}),
+      },
       spec: {
         version: k0sControlPlaneVersion,
         k0SConfig: {


### PR DESCRIPTION
Three defects found while bringing up the first live AWS workload cluster (dev), each of which halted provisioning at admission time before any AWS resource was created.

## 1. k0smotron hosted-CP Service annotations never reached the Service
k0smotron v2.x dropped `spec.service.annotations`; the controller now reads the
desired Service annotations only from the CR-level annotation
`k0smotron.io/conversion-dropped-service.annotations` (JSON-encoded). Without it the
control-plane NLB defaulted to `internal`, so cross-region workers could not reach the
API/konnectivity endpoints. `AwsWorkloadCluster` now emits that CR annotation from
`controlPlaneServiceAnnotations`.

## 2. AWSCluster rejected controlPlaneLoadBalancer sub-fields when DISABLED
On the hosted-CP path the AWSCluster sets `loadBalancerType: DISABLED` (k0smotron owns
the CP LB), but `_shared.ts` still emitted `additionalListeners`/`ingressRules`, which
the CAPA v1beta2 webhook rejects: `spec.controlPlaneLoadBalancer.additionalListeners:
Invalid value`. We now emit the bare `{ loadBalancerType }` when DISABLED; the
konnectivity listener + ingress rules apply only to the standalone-CP NLB path.

## 3. K0sWorkerConfigTemplate used the pre-conversion v1beta1 field
k0smotron v1beta2 renamed `preStartCommands` -> `preK0sCommands` with no stored
conversion, so applying the v1beta1 shape failed server-side apply with `field not
declared in schema` and no worker ever bootstrapped. `AwsWorkloadCluster` now emits the
`K0sWorkerConfigTemplateV1Beta2` class (`preK0sCommands`) and points the
MachineDeployment bootstrap `configRef` at `bootstrap.cluster.x-k8s.io/v1beta2`.

All three validated: `tsc --noEmit` clean, `example/aws.ts` synth clean, and the rendered
`aws-management.k8s.yaml` shows `preK0sCommands:` and the bare DISABLED LB block.