### PR TITLE
fix(storage): make Piraeus XRD structural

### DIFF
--- a/packages/nebula/src/modules/k8s/piraeus/ebs.ts
+++ b/packages/nebula/src/modules/k8s/piraeus/ebs.ts
@@ -193,7 +193,10 @@ export class PiraeusEbs extends BaseConstruct<PiraeusEbsConfig> {
                       availabilityZones: {
                         type: "array",
                         minItems: 1,
-                        uniqueItems: true,
+                        // Kubernetes structural schemas forbid
+                        // `uniqueItems: true`; a set list provides the same
+                        // uniqueness guarantee without quadratic validation.
+                        "x-kubernetes-list-type": "set",
                         items: { type: "string", minLength: 1 },
                       },
                       iamUserName: { type: "string", minLength: 1 },


### PR DESCRIPTION
## What changed

- replace `uniqueItems: true` on the Piraeus EBS availability-zone schema with Kubernetes structural set semantics
- preserve the uniqueness guarantee for availability zones

## Why

Kubernetes rejects `uniqueItems: true` in structural CRD schemas because its validation cost is quadratic. Crossplane therefore could not establish `xpiraeusebsconfigs.nebula.io`, blocking the Piraeus EBS composition during the AWS stage rollout.

## Validation

- `tsc --noEmit`
- synthesized a `PiraeusEbs` construct and verified the XRD renders `x-kubernetes-list-type: set` with no `uniqueItems`
