### PR TITLE
fix(storage): read Upbound AccessKey secret

### DIFF
--- a/packages/nebula/src/modules/k8s/piraeus/ebs.ts
+++ b/packages/nebula/src/modules/k8s/piraeus/ebs.ts
@@ -418,9 +418,13 @@ spec:
 {{ $accessKeyId = . }}
 {{ end }}{{ end }}{{ end }}
 {{ end }}
-{{ with .connectionDetails }}{{ with (index . "secret") }}
+{{ with .connectionDetails }}
+{{ with (index . "attribute.secret") }}
+{{ $accessKeySecret = . }}
+{{ else }}{{ with (index . "secret") }}
 {{ $accessKeySecret = . }}
 {{ end }}{{ end }}
+{{ end }}
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
## What changed

- read the Upbound IAM AccessKey secret from `attribute.secret`
- retain `secret` as a compatibility fallback for other provider versions

## Why

The AWS stage rollout showed that provider-aws writes `attribute.secret`, `password`, and `username` connection keys. The Piraeus composition expected `secret`, so it never rendered `linstor-passphrase` and the LINSTOR controller could not start.

## Validation

- `tsc --noEmit`
- synthesized `PiraeusEbs` and verified the generated composition template contains the Upbound key plus fallback
