### PR TITLE
fix(aws): allow Calico overlay traffic

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -178,6 +178,10 @@ export function emitAwsClusterCr(
      */
     loadBalancerScheme?: AwsClusterV1Beta2SpecControlPlaneLoadBalancerScheme;
     vpcCidr: string;
+    /** CNI selected in the k0s ClusterConfig. Used to emit matching AWS SG rules. */
+    networkProvider?: "kuberouter" | "calico" | "custom";
+    /** Bundled Calico transport settings (only used when networkProvider="calico"). */
+    calico?: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
     /**
      * Cap the number of AZs CAPA spreads subnets across. CAPA creates one NAT
      * gateway (and thus one Elastic IP) per AZ, so on EIP-constrained accounts set
@@ -304,6 +308,51 @@ export function emitAwsClusterCr(
               }
             : {}),
         },
+        // CAPA's Calico defaults only allow BGP (TCP 179) and IP-in-IP
+        // (protocol 4). k0s defaults its bundled Calico to VXLAN and can enable
+        // WireGuard, so those defaults silently drop all cross-node pod traffic
+        // on AWS. Make the selected transport explicit; CAPA applies these
+        // source-SG rules to both control-plane and worker node groups.
+        ...(opts.networkProvider === "calico"
+          ? {
+              cni: {
+                cniIngressRules: [
+                  {
+                    description: "bgp (calico)",
+                    protocol: "tcp",
+                    fromPort: 179,
+                    toPort: 179,
+                  },
+                  {
+                    description: "IP-in-IP (calico)",
+                    protocol: "4",
+                    fromPort: -1,
+                    toPort: 65535,
+                  },
+                  ...((opts.calico?.mode ?? "vxlan") === "vxlan"
+                    ? [
+                        {
+                          description: "VXLAN (calico)",
+                          protocol: "udp",
+                          fromPort: 4789,
+                          toPort: 4789,
+                        },
+                      ]
+                    : []),
+                  ...(opts.calico?.wireguard
+                    ? [
+                        {
+                          description: "WireGuard (calico)",
+                          protocol: "udp",
+                          fromPort: 51820,
+                          toPort: 51820,
+                        },
+                      ]
+                    : []),
+                ],
+              },
+            }
+          : {}),
         // Explicit subnets (existing 1a + added AZs): CAPA adopts existing ones by
         // AZ+CIDR and creates the rest. Required to grow AZs on a LIVE cluster, since
         // availabilityZoneUsageLimit only auto-derives subnets at VPC creation.

--- a/packages/nebula/src/modules/infra/aws/k0s-cluster.ts
+++ b/packages/nebula/src/modules/infra/aws/k0s-cluster.ts
@@ -244,6 +244,8 @@ export class AwsK0sCluster extends BaseConstruct<AwsK0sClusterConfig> {
         this.config.controlPlaneLoadBalancerScheme ??
         AwsClusterV1Beta2SpecControlPlaneLoadBalancerScheme.INTERNAL,
       vpcCidr,
+      networkProvider,
+      calico,
       availabilityZoneUsageLimit: this.config.availabilityZoneUsageLimit,
       secondaryCidrBlocks: this.config.secondaryCidrBlocks,
       subnets: this.config.subnets,

--- a/packages/nebula/src/modules/infra/aws/k0s-provider.ts
+++ b/packages/nebula/src/modules/infra/aws/k0s-provider.ts
@@ -113,6 +113,8 @@ export class AwsK0sProvider implements K0sInfraProvider<AwsMachineSpec> {
         this.config.controlPlaneLoadBalancerScheme ??
         AwsClusterV1Beta2SpecControlPlaneLoadBalancerScheme.INTERNAL,
       vpcCidr: this.config.vpcCidr ?? "10.0.0.0/16",
+      networkProvider: ctx.networkProvider,
+      calico: ctx.calico,
       availabilityZoneUsageLimit: this.config.availabilityZoneUsageLimit,
       secondaryCidrBlocks: this.config.secondaryCidrBlocks,
       subnets: this.config.subnets,

--- a/packages/nebula/src/modules/infra/k0s/cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/cluster.ts
@@ -71,6 +71,10 @@ export interface K0sControlPlaneOptions<M> {
 export interface EmitInfraClusterCtx {
   clusterName: string;
   namespace: string;
+  /** CNI selected in the k0s ClusterConfig, so cloud providers can open its node-to-node transport. */
+  networkProvider: "kuberouter" | "calico" | "custom";
+  /** Bundled Calico transport settings (only meaningful for networkProvider="calico"). */
+  calico: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
 }
 
 /**
@@ -227,7 +231,12 @@ export class K0sCluster<M> extends BaseConstruct<K0sClusterConfig<M>> {
 
     // 2. Infra cluster CR (AWSCluster/…) — CAPA owns the VPC/subnets/SGs and the
     //    control-plane load balancer.
-    provider.emitInfraCluster(this, { clusterName, namespace });
+    provider.emitInfraCluster(this, {
+      clusterName,
+      namespace,
+      networkProvider,
+      calico,
+    });
 
     // 3. Control-plane infra machine template (hash-named by the provider).
     const cpRef = provider.emitMachineTemplate(this, "control-plane-template", {


### PR DESCRIPTION
## What changed

- Propagate the selected k0s CNI configuration to AWS infrastructure providers.
- Emit CAPA CNI security-group rules for Calico VXLAN (`UDP 4789`) and optional WireGuard (`UDP 51820`).
- Preserve CAPA's BGP and IP-in-IP rules when the CNI rule list becomes explicit.

## Why

The AWS stage cluster runs k0s-bundled Calico in VXLAN mode with WireGuard enabled. CAPA only generated its default Calico BGP/IP-in-IP rules, so cross-node overlay packets were dropped by the EC2 security groups. Pods could only reach services backed by endpoints on the same node; Piraeus exposed this when two CSI node pods could not reach the LINSTOR controller or cluster DNS.

The rules remain limited to CAPA's control-plane/node security-group sources; neither port is exposed publicly.

## Impact

CAPA will reconcile the missing internal overlay rules in place. No node replacement or CNI reconfiguration is required.

## Validation

- `tsc --noEmit`
- Targeted `AwsK0sCluster` synthesis with Calico VXLAN + WireGuard
- Generated `AWSCluster.spec.network.cni.cniIngressRules` contains TCP 179, protocol 4, UDP 4789, and UDP 51820
