### PR TITLE
fix(storage): make Piraeus XRD upgrade-safe

### DIFF
--- a/packages/nebula/src/modules/k8s/piraeus/ebs.ts
+++ b/packages/nebula/src/modules/k8s/piraeus/ebs.ts
@@ -96,8 +96,6 @@ export class PiraeusEbs extends BaseConstruct<PiraeusEbsConfig> {
     const name = this.config.name ?? "piraeus-ebs";
     const httpProviderConfigRef =
       this.config.httpProviderConfigRef ?? "linstor-http";
-    const kubernetesProviderConfigRef =
-      this.config.kubernetesProviderConfigRef ?? "kubernetes-provider-config";
     const credentialSecretName =
       this.config.credentialSecretName ?? "linstor-ebs-aws-credentials";
     const credentialSecretNamespace =
@@ -240,7 +238,6 @@ export class PiraeusEbs extends BaseConstruct<PiraeusEbsConfig> {
                       "iamUserName",
                       "awsProviderConfigRef",
                       "httpProviderConfigRef",
-                      "kubernetesProviderConfigRef",
                       "credentialSecretName",
                       "credentialSecretNamespace",
                       "passphraseSecretName",
@@ -329,7 +326,12 @@ export class PiraeusEbs extends BaseConstruct<PiraeusEbsConfig> {
         awsProviderConfigRef:
           this.config.awsProviderConfigRef ?? "default",
         httpProviderConfigRef,
-        kubernetesProviderConfigRef,
+        ...(this.config.kubernetesProviderConfigRef
+          ? {
+              kubernetesProviderConfigRef:
+                this.config.kubernetesProviderConfigRef,
+            }
+          : {}),
         credentialSecretName,
         credentialSecretNamespace,
         passphraseSecretName,
@@ -351,6 +353,7 @@ export class PiraeusEbs extends BaseConstruct<PiraeusEbsConfig> {
 const PIRAEUS_EBS_TEMPLATE = String.raw`
 {{ $xr := .observed.composite.resource }}
 {{ $spec := $xr.spec }}
+{{ $kubernetesProviderConfigRef := default "kubernetes-provider-config" $spec.kubernetesProviderConfigRef }}
 ---
 apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
 kind: ExtraResources
@@ -658,7 +661,7 @@ spec:
   deletionPolicy: Orphan
   managementPolicies: [Observe, Update]
   providerConfigRef:
-    name: {{ $spec.kubernetesProviderConfigRef }}
+    name: {{ $kubernetesProviderConfigRef }}
   forProvider:
     manifest:
       apiVersion: v1


### PR DESCRIPTION
## What changed

- keep `kubernetesProviderConfigRef` optional in the Piraeus EBS XRD
- omit the field from generated XR instances unless a caller explicitly overrides it
- default to `kubernetes-provider-config` inside the Composition template

## Root cause

Argo computes the complete structured diff before applying sync waves. Adding a field to an XRD schema and using it in the XR in the same revision therefore fails against the old live schema before the XRD's earlier sync wave can run.

## Impact

Existing installations can update the XRD, Composition, and XR atomically. Fresh installations retain the same default provider configuration, and explicit overrides remain supported after the schema exists.

## Validation

- TypeScript check passed
- focused synth confirmed the XRD declares the optional field, does not require it, and the default XR omits it
- downstream frozen install and full `infra/piraeus` synth passed
