### PR TITLE
feat(storage): support pinning the LINSTOR server version

### DIFF
--- a/packages/nebula/src/modules/k8s/piraeus/index.ts
+++ b/packages/nebula/src/modules/k8s/piraeus/index.ts
@@ -16,7 +16,7 @@
  * ```
  */
 import { Construct } from "constructs";
-import { Include, ApiObject } from "cdk8s";
+import { Include, ApiObject, JsonPatch } from "cdk8s";
 import * as kplus from "cdk8s-plus-33";
 import { KubeStorageClass } from "cdk8s-plus-33/lib/imports/k8s";
 import { BaseConstruct } from "../../../core";
@@ -100,6 +100,12 @@ export interface PiraeusConfig {
   namespace?: string;
   /** Piraeus Operator version (defaults to "v2.10.7") */
   operatorVersion?: string;
+  /**
+   * Pin the LINSTOR server (controller + satellite) image tag, overriding the
+   * operator's default. Image-config keys merge in lexical order, so the
+   * override key sorts after the upstream "0_"-prefixed defaults.
+   */
+  linstorVersion?: string;
   /** StorageClass name (legacy shorthand; defaults to "linstor-encrypted") */
   storageClassName?: string;
   /** StorageClass configuration */
@@ -206,9 +212,36 @@ export class Piraeus extends BaseConstruct<PiraeusConfig> {
 
     // --- Piraeus Operator (includes the piraeus-datastore Namespace) ---
 
-    new Include(this, "piraeus-operator", {
+    const operatorInclude = new Include(this, "piraeus-operator", {
       url: `https://github.com/piraeusdatastore/piraeus-operator/releases/download/${operatorVersion}/manifest.yaml`,
     });
+
+    if (this.config.linstorVersion) {
+      const imageConfig = operatorInclude.apiObjects.find(
+        (o) =>
+          o.kind === "ConfigMap" &&
+          o.name === "piraeus-operator-image-config",
+      );
+      if (!imageConfig) {
+        throw new Error(
+          "Piraeus: piraeus-operator-image-config ConfigMap not found in the operator manifest",
+        );
+      }
+      imageConfig.addJsonPatch(
+        JsonPatch.add("/data/z_linstor_version_override.yaml", [
+          "---",
+          "base: quay.io/piraeusdatastore",
+          "components:",
+          "  linstor-controller:",
+          `    tag: ${this.config.linstorVersion}`,
+          "    image: piraeus-server",
+          "  linstor-satellite:",
+          `    tag: ${this.config.linstorVersion}`,
+          "    image: piraeus-server",
+          "",
+        ].join("\n")),
+      );
+    }
 
     // --- LINSTOR Passphrase Secret ---
 


### PR DESCRIPTION
Native EBS is broken in LINSTOR 1.33.3 (controller never dispatches EBS_TARGET resources to special satellites → no CreateVolume → attach fails on missing EBSVlmId; reproduced with plain CLI, CSI-independent). Adds `linstorVersion` to pin the server image (controller+satellite) via a lexically-later image-config key, so the EBS-era v1.30.4 can be deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)