### PR TITLE
fix(cli): point init-aws nebula-cdk8s pin at feat/standalone-cp-bootstrap

### DIFF
--- a/packages/cli/src/commands/init-aws.ts
+++ b/packages/cli/src/commands/init-aws.ts
@@ -13,7 +13,7 @@ import type { InitOptions } from "./init";
 
 // ── Packaging pins (single source so package.json and pnpm-workspace agree) ──────
 // nebula-cdk8s + @nebula/cli come from this branch; switch to `main` after merge.
-const NEBULA_BRANCH = "feat/aws-vendor-free-bootstrap";
+const NEBULA_BRANCH = "feat/standalone-cp-bootstrap";
 // The cdk8s-cli fork commit. MUST match the allowBuilds tarball URL below, or
 // pnpm 11 silently skips its build and `cdk8s synth` fails.
 const CDK8S_CLI_COMMIT = "ef8da23a33eecab4fe7cfcbcee911c374e20ca6f";


### PR DESCRIPTION
The scaffolded repo's `infra/cluster-api` imports `K0sCluster` + `AwsK0sProvider`, which only exist on `feat/standalone-cp-bootstrap`. The previous pin (`feat/aws-vendor-free-bootstrap`) predates the consolidation, so a fresh `nebula init --provider aws` scaffold could not synth. Verified the other two pins still resolve (cdk8s-cli tarball 200, nebula-cmp:b690209 manifest 200). Switch to `main` after the standalone-cp branch merges.

Found while running the live `nebula init` → `nebula bootstrap` AWS e2e smoke test that gates PR #12's Phase D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)