### PR TITLE
chore(cli): pin init-aws nebula-cdk8s dep to main

### DIFF
--- a/packages/cli/src/commands/init-aws.ts
+++ b/packages/cli/src/commands/init-aws.ts
@@ -12,8 +12,8 @@ import chalk from "chalk";
 import type { InitOptions } from "./init";
 
 // ── Packaging pins (single source so package.json and pnpm-workspace agree) ──────
-// nebula-cdk8s + @nebula/cli come from this branch; switch to `main` after merge.
-const NEBULA_BRANCH = "feat/standalone-cp-bootstrap";
+// nebula-cdk8s + @nebula/cli come from this branch.
+const NEBULA_BRANCH = "main";
 // The cdk8s-cli fork commit. MUST match the allowBuilds tarball URL below, or
 // pnpm 11 silently skips its build and `cdk8s synth` fails.
 const CDK8S_CLI_COMMIT = "ef8da23a33eecab4fe7cfcbcee911c374e20ca6f";


### PR DESCRIPTION
Follow-up to #23/#24: the standalone-cp consolidation is on main now, so `nebula init --provider aws` scaffolds should track `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)