### PR TITLE
fix(argocd): surface pnpm-install errors in the CMP init command

### DIFF
--- a/packages/nebula/src/modules/k8s/argocd/index.ts
+++ b/packages/nebula/src/modules/k8s/argocd/index.ts
@@ -725,7 +725,7 @@ export class ArgoCd extends HelmModule<ArgoCdConfig> {
               args: [
                 `set -e
 echo "Installing dependencies in $(pwd)..." >&2
-pnpm install 2>&1 >&2`,
+pnpm install >&2 2>&1`,
               ],
             },
             generate: {


### PR DESCRIPTION
`pnpm install 2>&1 >&2` routes both fd1 and fd2 to the manifest-capture pipe, so pnpm's output is discarded and a failed install reports a bare `exit status 1` with no reason. `>&2 2>&1` sends pnpm's stdout+stderr to the sidecar log (`kubectl logs ... -c nebula-cmp`) while keeping stdout clean.

Surfaced during the live `nebula init` → `nebula bootstrap` AWS e2e smoke test (the one gating the standalone-CP consolidation): a transient first-sync install failure was undiagnosable because this redirection hid the real error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)