### PR TITLE
fix(cli): scaffold cluster-scoped node instance-profile name

### DIFF
--- a/packages/cli/src/commands/init-aws.ts
+++ b/packages/cli/src/commands/init-aws.ts
@@ -586,6 +586,7 @@ const chart = new Chart(app, "node-iam");
 new Aws(chart, "aws", {
   name: config.aws.clusterName,
   region: config.aws.region,
+  instanceProfileName: \`\${config.aws.clusterName}-node-profile\`,
 });
 
 app.synth();
@@ -619,6 +620,7 @@ new K0sCluster(chart, "mgmt", {
   },
   provider: new AwsK0sProvider({
     region: config.aws.region,
+    iamInstanceProfile: \`\${config.aws.clusterName}-node-profile\`,
     // Internet-facing so the API is reachable for reconciliation; mTLS guards it.
     controlPlaneLoadBalancerScheme:
       AwsClusterV1Beta2SpecControlPlaneLoadBalancerScheme.INTERNET_HYPHEN_FACING,


### PR DESCRIPTION
Fixes #27.

`nebula init` scaffolds now emit a **cluster-scoped** worker instance-profile name (`${clusterName}-node-profile`) in both `infra/node-iam` (creator) and `infra/cluster-api` (the AWSMachineTemplate reference), instead of relying on the construct's shared CAPA default `nodes.cluster-api-provider-aws.sigs.k8s.io`.

**Why:** that default name is account-global, so two nebula clusters in one AWS account manage the *same* IAM instance profile through colliding Crossplane `external-name`s — each cluster's `instanceprofile` MR binds *its* role to the one shared profile and they fight. During the live `nebula init/bootstrap` AWS e2e (the #24 smoke test), the new cluster's Crossplane was found managing **stage's** node instance profile.

**Blast radius — deliberately minimal:** the fix is in the scaffold generators, not the exported construct default. Existing committed repos (e.g. stage) synth byte-identically — no control-plane reroll, no IAM migration. Only newly-scaffolded clusters get the scoped name. (Changing the construct default itself would rotate the CP AWSMachineTemplate spec-hash and reroll existing control planes on re-synth — see #27 for that deeper, migration-gated change.)

Verified: fresh `nebula init --provider aws` emits matching `${config.aws.clusterName}-node-profile` in both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)