### PR TITLE
fix(aws): enable cross-zone LB on the control-plane NLB

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -249,6 +249,15 @@ export function emitAwsClusterCr(
         // control-plane target can itself be an API client, and AWS NLB target
         // hairpinning is unsupported while client-IP preservation is enabled.
         preserveClientIp: false,
+        // MANDATORY on a multi-AZ control plane: an NLB has one node per AZ and,
+        // with cross-zone OFF (the AWS default), each AZ's node only forwards to
+        // the target in its OWN AZ. Both listeners here — 6443 (API) and 8132
+        // (konnectivity, below) — then reach only a 1/N slice of the control-plane
+        // targets, so the konnectivity agent<->server tunnels that carry every
+        // apiserver->pod call (admission webhooks, logs, exec) land unevenly and a
+        // large fraction (~50% on 3 AZs) time out. Enable cross-zone so every NLB
+        // node forwards to all healthy targets.
+        crossZoneLoadBalancing: true,
         ...(opts.loadBalancerScheme
           ? { scheme: opts.loadBalancerScheme }
           : {}),


### PR DESCRIPTION
A multi-AZ NLB has one node per AZ; with cross-zone **off** (AWS default) each AZ node only forwards to the target in its own AZ. Both the **6443** API listener and the **8132 konnectivity** listener (added in `_shared.ts`) then reach only a 1/N slice of the CP targets, so the konnectivity agent↔server tunnels carrying every apiserver→pod call (admission webhooks, logs, exec) land unevenly and **~50% (3 AZs) time out**.

Set `crossZoneLoadBalancing: true` on the CP NLB.

Found live: a fresh 3-AZ mgmt bootstrap stalled with ~50% apiserver→webhook i/o timeouts; enabling cross-zone on the live NLB moved the needle (50%→30%; the rest was stale konnectivity tunnels).

🤖 Generated with Claude Code