### PR TITLE
fix(aws): thread kubeletPath into AwsEbsCsiDriver for k0s

### DIFF
--- a/packages/nebula/src/modules/k8s/aws-ebs-csi-driver/index.ts
+++ b/packages/nebula/src/modules/k8s/aws-ebs-csi-driver/index.ts
@@ -72,6 +72,15 @@ export interface AwsEbsCsiDriverConfig {
    */
   clusterName?: string;
   /**
+   * Kubelet root path, mapped to the chart's `node.kubeletPath` (drives the
+   * driver's registration/plugin/kubelet hostPath mounts). Defaults to the
+   * chart default `/var/lib/kubelet`; k0s uses `/var/lib/k0s/kubelet`. Since
+   * this construct targets self-managed k0s clusters, set this to the k0s path
+   * or the node driver fails to register (no CSINode topology → provisioning
+   * errors with "no topology key found for node").
+   */
+  kubeletPath?: string;
+  /**
    * gp3 StorageClass rendered next to the driver. Created by default; pass
    * `false` to skip it, or an object to customize name/default-class/etc.
    * @default {}
@@ -115,6 +124,11 @@ export class AwsEbsCsiDriver extends HelmModule<AwsEbsCsiDriverConfig> {
         },
       },
       node: {
+        // k0s (and similar distros) use a non-standard kubelet root; without
+        // this the node driver's registration hostPath does not exist.
+        ...(this.config.kubeletPath
+          ? { kubeletPath: this.config.kubeletPath }
+          : {}),
         serviceAccount: {
           create: true,
           name: "ebs-csi-node-sa",


### PR DESCRIPTION
## Problem
The `aws-ebs-csi-driver` chart defaults `node.kubeletPath` to `/var/lib/kubelet`, but k0s clusters (which this construct explicitly targets — see its doc comment) use `/var/lib/k0s/kubelet`. On k0s the node driver's registration hostPath `/var/lib/kubelet/plugins_registry` does not exist, so:

- the `ebs-csi-node` DaemonSet is stuck `ContainerCreating` (`FailedMount: hostPath type check failed: /var/lib/kubelet/plugins_registry/ is not a directory`),
- no CSINode driver is registered → nodes carry no `topology.ebs.csi.aws.com/zone`,
- dynamic provisioning fails: `error generating accessibility requirements: no topology key found for node`.

Hit live on a fresh k0s mgmt-cluster bootstrap.

## Fix
Expose an optional `kubeletPath` prop (same pattern as `Calico` and `Piraeus`), mapped to the chart's `node.kubeletPath`. Verified via `helm template --set node.kubeletPath=/var/lib/k0s/kubelet` → registration-dir hostPath renders `/var/lib/k0s/kubelet/plugins_registry/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)