### PR TITLE
feat(cert-manager): make ACME HTTP-01 self-check nameservers configurable

### DIFF
--- a/packages/nebula/src/modules/k8s/aws-ebs-csi-driver/index.ts
+++ b/packages/nebula/src/modules/k8s/aws-ebs-csi-driver/index.ts
@@ -72,6 +72,15 @@ export interface AwsEbsCsiDriverConfig {
    */
   clusterName?: string;
   /**
+   * Kubelet root path, mapped to the chart's `node.kubeletPath` (drives the
+   * driver's registration/plugin/kubelet hostPath mounts). Defaults to the
+   * chart default `/var/lib/kubelet`; k0s uses `/var/lib/k0s/kubelet`. Since
+   * this construct targets self-managed k0s clusters, set this to the k0s path
+   * or the node driver fails to register (no CSINode topology → provisioning
+   * errors with "no topology key found for node").
+   */
+  kubeletPath?: string;
+  /**
    * gp3 StorageClass rendered next to the driver. Created by default; pass
    * `false` to skip it, or an object to customize name/default-class/etc.
    * @default {}
@@ -115,6 +124,11 @@ export class AwsEbsCsiDriver extends HelmModule<AwsEbsCsiDriverConfig> {
         },
       },
       node: {
+        // k0s (and similar distros) use a non-standard kubelet root; without
+        // this the node driver's registration hostPath does not exist.
+        ...(this.config.kubeletPath
+          ? { kubeletPath: this.config.kubeletPath }
+          : {}),
         serviceAccount: {
           create: true,
           name: "ebs-csi-node-sa",

--- a/packages/nebula/src/modules/k8s/cert-manager/index.ts
+++ b/packages/nebula/src/modules/k8s/cert-manager/index.ts
@@ -30,12 +30,24 @@ export interface CertManagerConfig {
   /** Create ClusterIssuers (defaults to true) */
   createClusterIssuers?: boolean;
   /**
-   * Use external recursive DNS servers for HTTP-01 ACME challenge self-checks.
-   * This is useful for GKE clusters where internal DNS may not resolve newly
-   * created domains immediately.
+   * Use external recursive DNS servers for HTTP-01 ACME challenge self-checks
+   * (sets `--acme-http01-solver-nameservers`). Useful for split-horizon clusters
+   * (e.g. GKE, whose metadata DNS can SERVFAIL on freshly created domains).
+   *
+   * Leave this FALSE when the in-cluster resolver reaches the zone's
+   * authoritative servers (e.g. AWS external-dns → Route53): public recursive
+   * resolvers lag when a zone is freshly created/recreated and will SERVFAIL the
+   * self-check for hours, whereas the in-cluster path resolves authoritatively.
    * @default true
    */
   useExternalDnsForAcme?: boolean;
+  /**
+   * Recursive nameservers used for the HTTP-01 self-check when
+   * {@link useExternalDnsForAcme} is true. Override to avoid hardcoding a single
+   * public provider.
+   * @default ["8.8.8.8:53", "8.8.4.4:53"]
+   */
+  acmeHttp01SolverNameservers?: string[];
   /**
    * IngressClassName used by the Let's Encrypt HTTP-01 solvers.
    * @default "nginx"
@@ -61,6 +73,10 @@ export class CertManager extends HelmModule<CertManagerConfig> {
     // Use external DNS servers for ACME HTTP-01 challenge self-checks by default.
     // GKE's internal DNS (via metadata server) can return SERVFAIL for newly created domains.
     const useExternalDns = this.config.useExternalDnsForAcme !== false;
+    const acmeSolverNameservers = this.config.acmeHttp01SolverNameservers ?? [
+      "8.8.8.8:53",
+      "8.8.4.4:53",
+    ];
     const acmeIngressClassName = this.config.acmeIngressClassName ?? "nginx";
 
     const defaultValues: Record<string, unknown> = {
@@ -70,7 +86,9 @@ export class CertManager extends HelmModule<CertManagerConfig> {
       cainjector: {},
       startupapicheck: {},
       ...(useExternalDns && {
-        extraArgs: ["--acme-http01-solver-nameservers=8.8.8.8:53,8.8.4.4:53"],
+        extraArgs: [
+          `--acme-http01-solver-nameservers=${acmeSolverNameservers.join(",")}`,
+        ],
       }),
     };
 


### PR DESCRIPTION
## Problem
The module hardcoded `--acme-http01-solver-nameservers=8.8.8.8:53,8.8.4.4:53`. Public recursive resolvers (Google) lag when a zone is freshly created/recreated and **SERVFAIL the HTTP-01 self-check for hours** (observed live on a fresh AWS mgmt cluster: 8.8.8.8 returned SERVFAIL on `AAAA`/`SOA` for the new Route53 zone while the authoritative servers answered NOERROR). This blocks all public TLS issuance until the public resolver converges.

## Fix
- Add `acmeHttp01SolverNameservers?: string[]` to override the servers (no longer hardcoded to one provider).
- Document that clusters whose in-cluster resolver reaches the zone's authoritative servers (e.g. AWS external-dns → Route53) should set `useExternalDnsForAcme: false` — the in-cluster path resolves a fresh zone immediately, avoiding public-resolver propagation lag.

Backward compatible: default behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)