### PR TITLE
feat(k0s): hosted control plane as a second, provider-independent class

### DIFF
--- a/packages/nebula/src/modules/infra/aws/k0s-provider.ts
+++ b/packages/nebula/src/modules/infra/aws/k0s-provider.ts
@@ -100,18 +100,26 @@ export class AwsK0sProvider implements K0sInfraProvider<AwsMachineSpec> {
   constructor(private readonly config: AwsK0sProviderConfig) {}
 
   emitInfraCluster(scope: Construct, ctx: EmitInfraClusterCtx): void {
+    // Hosted control plane (k0smotron on a management cluster) → k0smotron
+    // exposes the API, so CAPA must NOT front it: emit loadBalancerType DISABLED
+    // (the AWSCluster CR then omits every controlPlaneLoadBalancer sub-field,
+    // which CAPA's webhook requires). Standalone control plane → CAPA fronts the
+    // API with an NLB (default INTERNAL, or the configured scheme).
     emitAwsClusterCr(scope, {
       clusterName: ctx.clusterName,
       namespace: ctx.namespace,
       region: this.config.region,
       sshKeyName: this.config.sshKeyName,
-      // Standalone control plane on the cluster's own nodes → CAPA fronts the API
-      // with an NLB (default INTERNAL). No hosted control plane, so no DISABLED.
-      loadBalancerType:
-        AwsClusterV1Beta2SpecControlPlaneLoadBalancerLoadBalancerType.NLB,
-      loadBalancerScheme:
-        this.config.controlPlaneLoadBalancerScheme ??
-        AwsClusterV1Beta2SpecControlPlaneLoadBalancerScheme.INTERNAL,
+      loadBalancerType: ctx.hostedControlPlane
+        ? AwsClusterV1Beta2SpecControlPlaneLoadBalancerLoadBalancerType.DISABLED
+        : AwsClusterV1Beta2SpecControlPlaneLoadBalancerLoadBalancerType.NLB,
+      ...(ctx.hostedControlPlane
+        ? {}
+        : {
+            loadBalancerScheme:
+              this.config.controlPlaneLoadBalancerScheme ??
+              AwsClusterV1Beta2SpecControlPlaneLoadBalancerScheme.INTERNAL,
+          }),
       vpcCidr: this.config.vpcCidr ?? "10.0.0.0/16",
       networkProvider: ctx.networkProvider,
       calico: ctx.calico,

--- a/packages/nebula/src/modules/infra/k0s/cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/cluster.ts
@@ -75,6 +75,14 @@ export interface EmitInfraClusterCtx {
   networkProvider: "kuberouter" | "calico" | "custom";
   /** Bundled Calico transport settings (only meaningful for networkProvider="calico"). */
   calico: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
+  /**
+   * Whether the control plane is HOSTED (k0smotron pods on a management cluster)
+   * rather than standalone (on this cluster's own machines). When true the
+   * provider must NOT front the API with its own load balancer — k0smotron
+   * exposes it — e.g. `AwsK0sProvider` emits its `AWSCluster` with
+   * `loadBalancerType: DISABLED`. Standalone {@link K0sCluster} passes false.
+   */
+  hostedControlPlane: boolean;
 }
 
 /**
@@ -154,7 +162,7 @@ export const DEFAULT_PRESTART_COMMANDS: readonly string[] = [
 ];
 
 /** Render `k0s worker` --labels/--taints args from a pool's labels/taints. */
-function renderK0sWorkerArgs<M>(pool: K0sWorkerPool<M>): string[] {
+export function renderK0sWorkerArgs<M>(pool: K0sWorkerPool<M>): string[] {
   const args: string[] = [];
   if (pool.nodeLabels && Object.keys(pool.nodeLabels).length > 0) {
     args.push(
@@ -236,6 +244,7 @@ export class K0sCluster<M> extends BaseConstruct<K0sClusterConfig<M>> {
       namespace,
       networkProvider,
       calico,
+      hostedControlPlane: false,
     });
 
     // 3. Control-plane infra machine template (hash-named by the provider).

--- a/packages/nebula/src/modules/infra/k0s/index.ts
+++ b/packages/nebula/src/modules/infra/k0s/index.ts
@@ -1,13 +1,16 @@
 /**
- * infra/k0s — provider-agnostic, self-managed k0s cluster via Cluster API with a
- * standalone control plane. The provider-specific infrastructure (AWSCluster /
- * GCPCluster + machine templates) is supplied by a pluggable
- * {@link K0sInfraProvider} (e.g. `AwsK0sProvider` in ../aws), so one base
- * construct serves every cloud. Repurposed by the k0rdent refactor as the emit
- * engine that generates the cluster-shape Helm chart a k0rdent `ClusterTemplate`
- * wraps.
+ * infra/k0s — provider-agnostic, self-managed k0s clusters via Cluster API. Two
+ * cluster classes mirror the k0smotron package's two control-plane kinds, sharing
+ * one pluggable {@link K0sInfraProvider} (e.g. `AwsK0sProvider` in ../aws) for the
+ * provider-specific infrastructure (AWSCluster / GCPCluster + machine templates):
+ *   - {@link K0sCluster} — STANDALONE control plane (`K0sControlPlane`, on the
+ *     cluster's own machines of provider M).
+ *   - {@link K0smotronCluster} — HOSTED control plane ({@link K0smotronControlPlane}
+ *     pods on a management cluster; provider-independent CP) + provider workers.
+ * `K0sCluster` is also repurposed by the k0rdent refactor as the emit engine that
+ * generates the cluster-shape Helm chart a k0rdent `ClusterTemplate` wraps.
  */
-export { K0sCluster } from "./cluster";
+export { K0sCluster, renderK0sWorkerArgs } from "./cluster";
 export type {
   K0sClusterConfig,
   K0sControlPlaneOptions,
@@ -18,3 +21,13 @@ export type {
   EmitInfraClusterCtx,
   EmitMachineTemplateCtx,
 } from "./cluster";
+export { K0smotronControlPlane } from "./k0smotron-control-plane";
+export type {
+  K0smotronControlPlaneConfig,
+  K0smotronControlPlanePersistence,
+} from "./k0smotron-control-plane";
+export { K0smotronCluster } from "./k0smotron-cluster";
+export type {
+  K0smotronClusterConfig,
+  K0smotronClusterControlPlane,
+} from "./k0smotron-cluster";

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
@@ -1,0 +1,185 @@
+import { Construct } from "constructs";
+import { BaseConstruct } from "../../../core";
+import { ClusterV1Beta2, MachineDeploymentV1Beta1 } from "#imports/cluster.x-k8s.io";
+import { K0sWorkerConfigTemplateV1Beta2 } from "#imports/bootstrap.cluster.x-k8s.io";
+import { K0SmotronControlPlaneV1Beta2SpecServiceType } from "#imports/controlplane.cluster.x-k8s.io";
+import {
+  DEFAULT_PRESTART_COMMANDS,
+  renderK0sWorkerArgs,
+  type K0sInfraProvider,
+  type K0sWorkerPool,
+} from "./cluster";
+import {
+  K0smotronControlPlane,
+  type K0smotronControlPlanePersistence,
+} from "./k0smotron-control-plane";
+
+/** Hosted control-plane options (provider-independent — see {@link K0smotronControlPlane}). */
+export interface K0smotronClusterControlPlane {
+  /** Hosted-etcd persistence (default emptyDir; prefer PVC on a persistent mgmt cluster). */
+  persistence?: K0smotronControlPlanePersistence;
+  /** API Service type on the hosting cluster (default LoadBalancer). */
+  serviceType?: K0SmotronControlPlaneV1Beta2SpecServiceType;
+  /** API Service annotations (hosting-cluster LB specifics, e.g. AWS NLB scheme). */
+  serviceAnnotations?: Record<string, string>;
+}
+
+export interface K0smotronClusterConfig<M> {
+  /** Cluster name (also the CAPI Cluster / infra-cluster name). */
+  name: string;
+  /** Namespace for the CAPI objects on the hosting cluster (default "default"). */
+  namespace?: string;
+  /** Kubernetes version (e.g. "v1.31.8"); the k0s variant is derived from it. */
+  k8sVersion?: string;
+  /** Pod CIDR (default "10.244.0.0/16"). */
+  podCidr?: string;
+  /** Service CIDR (default "10.96.0.0/12"). */
+  serviceCidr?: string;
+  /** Hosted control plane (K0smotronControlPlane pods on the hosting cluster). */
+  controlPlane?: K0smotronClusterControlPlane;
+  /** Worker pools keyed by pool name (each a MachineDeployment). */
+  workerPools?: Record<string, K0sWorkerPool<M>>;
+  /** Infrastructure provider adapter for the WORKERS (AWS now; GCP/others later). */
+  provider: K0sInfraProvider<M>;
+}
+
+/**
+ * K0smotronCluster — a self-managed k0s cluster with a HOSTED control plane: the
+ * CP runs as k0smotron pods in the hosting (management) cluster, while the workers
+ * are provider-managed machines. Sibling to the standalone-CP {@link K0sCluster};
+ * the two mirror the k0smotron package's two control-plane kinds
+ * (`K0smotronControlPlane` vs `K0sControlPlane`).
+ *
+ * The control plane ({@link K0smotronControlPlane}) is provider-INDEPENDENT; only
+ * the workers carry a {@link K0sInfraProvider} `M`. The provider is told the CP is
+ * hosted (`hostedControlPlane: true`) so it emits its infra cluster with the API
+ * load balancer DISABLED — k0smotron exposes the API via a Service on the hosting
+ * cluster, not via the workers' infra provider. CNI is "custom" (installed
+ * separately into the workload cluster, e.g. the `Calico` module).
+ */
+export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>> {
+  constructor(scope: Construct, id: string, config: K0smotronClusterConfig<M>) {
+    super(scope, id, config);
+
+    const name = this.config.name;
+    const namespace = this.config.namespace ?? "default";
+    const k8sVersion = this.config.k8sVersion ?? "v1.31.8";
+    const k0sVersion = `${k8sVersion}+k0s.0`;
+    const podCidr = this.config.podCidr ?? "10.244.0.0/16";
+    const serviceCidr = this.config.serviceCidr ?? "10.96.0.0/12";
+    const provider = this.config.provider;
+
+    const clusterName = name;
+    const controlPlaneName = `${name}-control-plane`;
+
+    // 1. CAPI Cluster — control plane is a hosted K0smotronControlPlane; infra ref
+    //    supplied by the provider (workers' AWSCluster/…).
+    new ClusterV1Beta2(this, "cluster", {
+      metadata: { name: clusterName, namespace },
+      spec: {
+        clusterNetwork: {
+          pods: { cidrBlocks: [podCidr] },
+          services: { cidrBlocks: [serviceCidr] },
+        },
+        controlPlaneRef: {
+          apiGroup: "controlplane.cluster.x-k8s.io",
+          kind: "K0smotronControlPlane",
+          name: controlPlaneName,
+        },
+        infrastructureRef: {
+          apiGroup: provider.infraClusterApiGroup,
+          kind: provider.infraClusterKind,
+          name: clusterName,
+        },
+      },
+    });
+
+    // 2. Infra cluster CR (AWSCluster/…) — CAPA owns the VPC/subnets/SGs; the API
+    //    load balancer is DISABLED (k0smotron exposes the API). networkProvider is
+    //    "custom" (a CNI is installed separately into the workload cluster).
+    provider.emitInfraCluster(this, {
+      clusterName,
+      namespace,
+      networkProvider: "custom",
+      calico: {},
+      hostedControlPlane: true,
+    });
+
+    // 3. Hosted control plane — pods on the hosting cluster (provider-independent).
+    new K0smotronControlPlane(this, "control-plane", {
+      name: controlPlaneName,
+      namespace,
+      k8sVersion,
+      podCidr,
+      serviceCidr,
+      persistence: this.config.controlPlane?.persistence,
+      serviceType: this.config.controlPlane?.serviceType,
+      serviceAnnotations: this.config.controlPlane?.serviceAnnotations,
+    });
+
+    // 4. Worker pools — per pool: infra machine template (provider) +
+    //    K0sWorkerConfigTemplate (cloud-init + native --labels/--taints) +
+    //    MachineDeployment (static replicas, no autoscaler). Identical to the
+    //    standalone K0sCluster's worker emission.
+    for (const [poolName, pool] of Object.entries(this.config.workerPools ?? {})) {
+      const infraRef = provider.emitMachineTemplate(
+        this,
+        `worker-template-${poolName}`,
+        {
+          baseName: `${name}-${poolName}`,
+          namespace,
+          role: "worker",
+          machine: pool.machine,
+        },
+      );
+
+      const workerConfigName = `${name}-${poolName}-config`;
+      const wargs = renderK0sWorkerArgs(pool);
+      new K0sWorkerConfigTemplateV1Beta2(this, `worker-config-${poolName}`, {
+        metadata: { name: workerConfigName, namespace },
+        spec: {
+          template: {
+            spec: {
+              version: k0sVersion,
+              ...(wargs.length ? { args: wargs } : {}),
+              preK0SCommands: [
+                ...DEFAULT_PRESTART_COMMANDS,
+                ...(pool.extraPreStartCommands ?? []),
+              ],
+            },
+          },
+        },
+      });
+
+      new MachineDeploymentV1Beta1(this, `worker-md-${poolName}`, {
+        metadata: { name: `${name}-${poolName}`, namespace },
+        spec: {
+          clusterName,
+          replicas: pool.replicas ?? 2,
+          selector: {
+            matchLabels: { "cluster.x-k8s.io/cluster-name": clusterName },
+          },
+          template: {
+            spec: {
+              clusterName,
+              version: k8sVersion,
+              ...(pool.failureDomain ? { failureDomain: pool.failureDomain } : {}),
+              bootstrap: {
+                configRef: {
+                  apiVersion: "bootstrap.cluster.x-k8s.io/v1beta2",
+                  kind: "K0sWorkerConfigTemplate",
+                  name: workerConfigName,
+                },
+              },
+              infrastructureRef: {
+                apiVersion: infraRef.apiVersion,
+                kind: infraRef.kind,
+                name: infraRef.name,
+              },
+            },
+          },
+        },
+      });
+    }
+  }
+}

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
@@ -1,0 +1,148 @@
+import { Construct } from "constructs";
+import { BaseConstruct } from "../../../core";
+import {
+  K0smotronControlPlaneV1Beta2,
+  K0SmotronControlPlaneV1Beta2SpecServiceType,
+  K0SmotronControlPlaneV1Beta2SpecPersistence,
+  K0SmotronControlPlaneV1Beta2SpecPersistencePersistentVolumeClaimSpecResourcesRequests,
+  K0SmotronControlPlaneV1Beta2SpecPatches,
+  K0SmotronControlPlaneV1Beta2SpecPatchesPatchType,
+} from "#imports/controlplane.cluster.x-k8s.io";
+
+/** Hosted-etcd persistence for the k0smotron control plane. */
+export type K0smotronControlPlanePersistence =
+  | { type: "emptyDir" }
+  | {
+      type: "pvc";
+      /** StorageClass on the HOSTING (management) cluster (e.g. "standard-rwo"). */
+      storageClass?: string;
+      /** PVC size (default "5Gi"). */
+      size?: string;
+      /** Access modes (default ["ReadWriteOnce"]). */
+      accessModes?: string[];
+    };
+
+export interface K0smotronControlPlaneConfig {
+  /** CR name (the CAPI `Cluster.spec.controlPlaneRef.name`). */
+  name: string;
+  /** Namespace on the hosting cluster (default "default"). */
+  namespace?: string;
+  /** Kubernetes version (e.g. "v1.31.8"); the k0s variant is `${k8sVersion}+k0s.0`. */
+  k8sVersion?: string;
+  /** Pod CIDR (default "10.244.0.0/16"). */
+  podCidr?: string;
+  /** Service CIDR (default "10.96.0.0/12"). */
+  serviceCidr?: string;
+  /** Hosted-etcd persistence (default emptyDir). */
+  persistence?: K0smotronControlPlanePersistence;
+  /**
+   * Service type for the hosted API endpoint — this Service runs in the HOSTING
+   * cluster, so it uses that cluster's LB (not the workers' infra provider).
+   * Default "LoadBalancer".
+   */
+  serviceType?: K0SmotronControlPlaneV1Beta2SpecServiceType;
+  /**
+   * Annotations for the API Service — hosting-cluster LB specifics, e.g. an AWS
+   * NLB scheme. k0smotron v2's v1beta2 `spec.service` cannot carry annotations,
+   * so they are injected via `spec.patches` (a MERGE patch on the generated
+   * `Service`, matched by Kind + `app.kubernetes.io/component: control-plane`).
+   * Without an explicit internet-facing scheme the AWS LB Controller defaults the
+   * NLB to "internal" and workers in another VPC cannot reach the CP.
+   */
+  serviceAnnotations?: Record<string, string>;
+}
+
+/**
+ * K0smotronControlPlane — a HOSTED k0s control plane: etcd + k0s controllers run
+ * as pods in the HOSTING (management) cluster, and k0smotron exposes the API via
+ * a Service on that cluster. Provider-INDEPENDENT by design (no worker-machine
+ * type parameter): the hosting substrate is decoupled from where the workers run,
+ * so one management cluster can host the control plane of a workload cluster whose
+ * workers live on any infra provider (AWS/GCP/bare-metal).
+ *
+ * Pair with a worker fleet + infra `Cluster`/`AWSCluster(DISABLED LB)` — see
+ * {@link K0smotronCluster}, which composes this CP with worker pools over a
+ * {@link K0sInfraProvider}.
+ */
+export class K0smotronControlPlane extends BaseConstruct<K0smotronControlPlaneConfig> {
+  constructor(scope: Construct, id: string, config: K0smotronControlPlaneConfig) {
+    super(scope, id, config);
+
+    const namespace = this.config.namespace ?? "default";
+    const k8sVersion = this.config.k8sVersion ?? "v1.31.8";
+    // k0smotron expects a SemVer; the canonical k0s suffix is "+k0s.0" (build
+    // metadata), NOT "-k0s.0" (a pre-release, k0smotron issue #1027).
+    const version = `${k8sVersion}+k0s.0`;
+    const podCidr = this.config.podCidr ?? "10.244.0.0/16";
+    const serviceCidr = this.config.serviceCidr ?? "10.96.0.0/12";
+
+    const cpPersistence = this.config.persistence;
+    const persistence: K0SmotronControlPlaneV1Beta2SpecPersistence =
+      cpPersistence?.type === "pvc"
+        ? {
+            type: "pvc",
+            persistentVolumeClaim: {
+              spec: {
+                accessModes: cpPersistence.accessModes ?? ["ReadWriteOnce"],
+                ...(cpPersistence.storageClass
+                  ? { storageClassName: cpPersistence.storageClass }
+                  : {}),
+                resources: {
+                  // The generated `requests` values are a Quantity wrapper whose
+                  // serializer reads `.value`; a bare string renders `storage:
+                  // null`, so wrap the size with the Quantity type.
+                  requests: {
+                    storage:
+                      K0SmotronControlPlaneV1Beta2SpecPersistencePersistentVolumeClaimSpecResourcesRequests.fromString(
+                        cpPersistence.size ?? "5Gi",
+                      ),
+                  },
+                },
+              },
+            },
+          }
+        : { type: "emptyDir" };
+
+    const servicePatches: K0SmotronControlPlaneV1Beta2SpecPatches[] = this.config
+      .serviceAnnotations
+      ? [
+          {
+            target: { kind: "Service", component: "control-plane" },
+            patch: {
+              type: K0SmotronControlPlaneV1Beta2SpecPatchesPatchType.MERGE,
+              content: JSON.stringify({
+                metadata: { annotations: this.config.serviceAnnotations },
+              }),
+            },
+          },
+        ]
+      : [];
+
+    new K0smotronControlPlaneV1Beta2(this, "control-plane", {
+      metadata: { name: this.config.name, namespace },
+      spec: {
+        version,
+        k0SConfig: {
+          apiVersion: "k0s.k0sproject.io/v1beta1",
+          kind: "ClusterConfig",
+          spec: {
+            network: {
+              // CNI is installed separately (e.g. the Calico module) into the
+              // workload cluster; k0s installs no CNI.
+              provider: "custom",
+              podCIDR: podCidr,
+              serviceCIDR: serviceCidr,
+            },
+          },
+        },
+        persistence,
+        service: {
+          type:
+            this.config.serviceType ??
+            K0SmotronControlPlaneV1Beta2SpecServiceType.LOAD_BALANCER,
+        },
+        ...(servicePatches.length ? { patches: servicePatches } : {}),
+      },
+    });
+  }
+}


### PR DESCRIPTION
Adds a **hosted control-plane** cluster class alongside the standalone one, mirroring how the k0smotron package ships two CP kinds (`K0sControlPlane` vs `K0smotronControlPlane`).

- **`K0smotronControlPlane`** — new, **provider-independent** construct (no worker `M`): emits the `K0smotronControlPlane` CR (CP pods on the hosting/mgmt cluster) — `version +k0s.0`, `network: custom`, `emptyDir|PVC` persistence, Service + annotation-patches for the hosting-cluster LB.
- **`K0smotronCluster<M>`** — hosted cluster class, sibling to `K0sCluster<M>`: CAPI `Cluster` (`controlPlaneRef → K0smotronControlPlane`) + the hosted CP + worker pools over `K0sInfraProvider<M>`. No CP machine template (CP is pods).
- **`AwsK0sProvider`** hosted hook: `EmitInfraClusterCtx.hostedControlPlane` → emits `AWSCluster` with `loadBalancerType: DISABLED` (k0smotron exposes the API), reusing the surviving `_shared.ts` DISABLED branch. Standalone `K0sCluster` untouched.

Restores the hosted-CP capability deleted in the `362a9b6` consolidation, but provider-agnostically (per the design: an AWS mgmt cluster can host the CP of a GCP-worker cluster). Validated: `tsc` clean; `cdk8s synth` of a `K0smotronCluster` emits the correct CRs (Cluster→K0smotronControlPlane, AWSCluster DISABLED, one worker AWSMachineTemplate, K0smotronControlPlane with custom network + PVC + NLB annotations).

Note: stacked on the cross-zone / ebs-csi-kubelet / cert-manager-nameservers fix branches (PRs #29–#31); those commits appear here until they merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)