### PR TITLE
fix(monitoring): correct Thanos sidecar discovery service name

### DIFF
--- a/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
@@ -359,8 +359,9 @@ export class PrometheusOperator extends HelmModule<PrometheusOperatorConfig> {
             : {}),
         },
         // Expose the sidecar gRPC store + a ServiceMonitor so Thanos Query can
-        // discover it (releaseName "prometheus" → service
-        // "prometheus-kube-prometheus-stack-thanos-discovery").
+        // discover it. kube-prometheus-stack's fullname truncates to
+        // "kube-prometheus", so releaseName "prometheus" → service
+        // "prometheus-kube-prometheus-thanos-discovery" (NOT "...-stack-...").
         ...(thanosEnabled
           ? {
               thanosService: { enabled: true },
@@ -758,8 +759,9 @@ export class PrometheusOperator extends HelmModule<PrometheusOperatorConfig> {
           stores: [
             // Local Prometheus Thanos sidecar. kube-prometheus-stack (releaseName
             // "prometheus" + thanosService.enabled) exposes the sidecar gRPC store
-            // as service "prometheus-kube-prometheus-stack-thanos-discovery:10901".
-            `dnssrv+_grpc._tcp.prometheus-kube-prometheus-stack-thanos-discovery.${namespaceName}.svc.cluster.local`,
+            // as service "prometheus-kube-prometheus-thanos-discovery:10901" (the
+            // chart's fullname truncates to "kube-prometheus" — no "-stack-").
+            `dnssrv+_grpc._tcp.prometheus-kube-prometheus-thanos-discovery.${namespaceName}.svc.cluster.local`,
             // Cross-cluster stores (e.g. another cluster's sidecar/store gRPC).
             // NOTE: do NOT add the local thanos-storegateway here — the bitnami
             // chart auto-injects it when storegateway.enabled. Adding it explicitly


### PR DESCRIPTION
Thanos Query's sidecar --store endpoint used
prometheus-kube-prometheus-STACK-thanos-discovery, but kube-prometheus-stack's fullname truncates to "kube-prometheus", so with releaseName "prometheus" the sidecar service is prometheus-kube-prometheus-thanos-discovery (no -stack-). The SRV lookup NXDOMAIN'd, so Thanos Query never connected the Prometheus sidecar — only the storegateway (S3 blocks) — and recent data (last hours, held only in the sidecar) was invisible: the Thanos Grafana datasource returned nothing for now-anchored queries. Drop the erroneous -stack- segment.