### PR TITLE
Monitoring hardening: Thanos resources, cmp tsx synth, spoke raw-only remote-write

### DIFF
--- a/packages/nebula/src/modules/k8s/argocd/index.ts
+++ b/packages/nebula/src/modules/k8s/argocd/index.ts
@@ -742,9 +742,14 @@ if [ ! -f "$ENTRY" ]; then
   echo "ERROR: Entry file not found: $ENTRY" >&2
   exit 1
 fi
-echo "Running cdk8s synth for $ENTRY..." >&2
+echo "Synthesizing $ENTRY..." >&2
 rm -rf dist
-npx cdk8s synth --app "npx tsx $ENTRY" >&2
+# Run the entry directly with tsx — each module calls app.synth() which writes
+# to dist/ (App outdir defaults to "dist", enforced via CDK8S_OUTDIR). This
+# avoids the cdk8s-cli wrapper, whose git-tarball install has a fragile
+# "npx tsc --build || true" prepare step that silently ships no lib/ on a cold
+# cmp install, breaking synth for every app after a repo-server restart.
+CDK8S_OUTDIR=dist npx tsx "$ENTRY" >&2
 for f in $(find dist -name "*.yaml" -type f | sort); do
   echo "---"
   cat "$f"

--- a/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
@@ -774,6 +774,14 @@ export class PrometheusOperator extends HelmModule<PrometheusOperatorConfig> {
             annotations: componentSaAnnotations,
           },
         },
+        query: {
+          // Bitnami's default resourcesPreset ("micro", 192Mi) is far too small
+          // for the fan-out merge under real dashboard load; give query room.
+          resources: {
+            requests: { cpu: "100m", memory: "256Mi" },
+            limits: { memory: "1Gi" },
+          },
+        },
         queryFrontend: { enabled: true, tolerations: defaultTolerations },
         storegateway: {
           enabled: true,
@@ -782,6 +790,15 @@ export class PrometheusOperator extends HelmModule<PrometheusOperatorConfig> {
             enabled: true,
             storageClass: storageClassName,
             size: "10Gi",
+          },
+          // The in-memory index cache alone is ~250Mi, so Bitnami's default
+          // "micro" preset (192Mi limit) OOM-crashloops the moment a query
+          // touches S3 blocks — the store then drops out of Thanos Query and
+          // ALL long-term/recent metrics disappear. Size for the cache + the
+          // per-query series working set.
+          resources: {
+            requests: { cpu: "100m", memory: "1Gi" },
+            limits: { memory: "2Gi" },
           },
           serviceAccount: {
             create: true,
@@ -796,6 +813,12 @@ export class PrometheusOperator extends HelmModule<PrometheusOperatorConfig> {
             enabled: true,
             storageClass: storageClassName,
             size: "10Gi",
+          },
+          // Compaction (esp. vertical/downsampling) is memory-heavy; the 192Mi
+          // "micro" preset OOMs it. Give it headroom so blocks keep compacting.
+          resources: {
+            requests: { cpu: "100m", memory: "1Gi" },
+            limits: { memory: "2Gi" },
           },
           serviceAccount: {
             create: true,

--- a/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
@@ -773,8 +773,6 @@ export class PrometheusOperator extends HelmModule<PrometheusOperatorConfig> {
             name: "thanos-query",
             annotations: componentSaAnnotations,
           },
-        },
-        query: {
           // Bitnami's default resourcesPreset ("micro", 192Mi) is far too small
           // for the fan-out merge under real dashboard load; give query room.
           resources: {

--- a/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
@@ -153,10 +153,13 @@ export class MemberMonitoring extends BaseConstruct<MemberMonitoringConfig> {
               // the hub rejects them "400 out of order sample"
               // (PrometheusRemoteStorageFailures). Hub-evaluated rules are
               // canonical; this also trims remote-write traffic.
+              // ALERTS/ALERTS_FOR_STATE (the synthetic alert-state series)
+              // collide the same way: the hub's rule evaluation over this
+              // spoke's raw series emits its own ALERTS{cluster=<spoke>,...}.
               writeRelabelConfigs: [
                 {
                   sourceLabels: ["__name__"],
-                  regex: ".+:.+",
+                  regex: ".+:.+|ALERTS|ALERTS_FOR_STATE",
                   action: "drop",
                 },
               ],

--- a/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
@@ -144,6 +144,22 @@ export class MemberMonitoring extends BaseConstruct<MemberMonitoringConfig> {
                 username: { name: rwSecretName, key: "username" },
                 password: { name: rwSecretName, key: "password" },
               },
+              // Ship RAW series only — drop recording-rule outputs (":" in the
+              // name by convention). The central hub runs the same kube-
+              // prometheus-stack rules and evaluates them over this spoke's
+              // remote-written raw series, producing IDENTICAL label sets
+              // (cluster/env/prometheus_replica come from the inputs) with
+              // fresher timestamps — so spoke-shipped rule outputs collide and
+              // the hub rejects them "400 out of order sample"
+              // (PrometheusRemoteStorageFailures). Hub-evaluated rules are
+              // canonical; this also trims remote-write traffic.
+              writeRelabelConfigs: [
+                {
+                  sourceLabels: ["__name__"],
+                  regex: ".+:.+",
+                  action: "drop",
+                },
+              ],
             },
           ],
         },


### PR DESCRIPTION
Follow-ups to #33 (already-merged sidecar discovery-name fix), all verified live on the AWS mgmt hub + cicd/mainnet spokes:

- **Thanos memory limits** — bitnami's `micro` preset (192Mi) OOM-crashlooped the storegateway (index cache alone ~250Mi), blanking the whole datasource. Explicit resources for storegateway/compactor (1Gi/2Gi) and query (256Mi/1Gi).
- **Query resources merged into the existing `query` block** — the initial commit added a duplicate `query:` key that silently clobbered `query.stores` (last-wins), dropping the sidecar endpoint.
- **nebula-cmp runs `tsx` directly** (`CDK8S_OUTDIR=dist npx tsx $ENTRY`) — the cdk8s-cli git-tarball's fragile prepare (`tsc --build || true`, then `yarn install` on a corrupt cache) broke every app's synth after a repo-server restart (global GitOps stall).
- **MemberMonitoring ships raw series only** — drops `.+:.+` rule outputs and `ALERTS|ALERTS_FOR_STATE` from remote-write: the hub evaluates the same rules over spoke series and produces identical label sets with fresher timestamps, so spoke copies were rejected `400 out of order sample` (PrometheusRemoteStorageFailures at ~2.6%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)