### PR TITLE
fix(monitoring): drop alertmanagers_discovered from spoke remote-write

### DIFF
--- a/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
@@ -156,10 +156,15 @@ export class MemberMonitoring extends BaseConstruct<MemberMonitoringConfig> {
               // ALERTS/ALERTS_FOR_STATE (the synthetic alert-state series)
               // collide the same way: the hub's rule evaluation over this
               // spoke's raw series emits its own ALERTS{cluster=<spoke>,...}.
+              // prometheus_notifications_alertmanagers_discovered is dropped
+              // because a spoke has no Alertmanager BY DESIGN — shipping it
+              // makes the hub's PrometheusNotConnectedToAlertmanagers rule
+              // fire a permanent false positive per spoke.
               writeRelabelConfigs: [
                 {
                   sourceLabels: ["__name__"],
-                  regex: ".+:.+|ALERTS|ALERTS_FOR_STATE",
+                  regex:
+                    ".+:.+|ALERTS|ALERTS_FOR_STATE|prometheus_notifications_alertmanagers_discovered",
                   action: "drop",
                 },
               ],


### PR DESCRIPTION
MemberMonitoring spokes disable the local Alertmanager by design, so the hub's PrometheusNotConnectedToAlertmanagers rule (evaluated over spoke-shipped raw series) fires a permanent false positive per spoke (seen on cicd + stage). Drop the metric at the spoke's remote-write boundary alongside recording-rule outputs and ALERTS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)