### PR TITLE
feat(k0s): resources + topologySpreadConstraints on the hosted CP

### DIFF
--- a/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
@@ -2,7 +2,10 @@ import { Construct } from "constructs";
 import { BaseConstruct } from "../../../core";
 import { ClusterV1Beta2, MachineDeploymentV1Beta1 } from "#imports/cluster.x-k8s.io";
 import { K0sWorkerConfigTemplateV1Beta2 } from "#imports/bootstrap.cluster.x-k8s.io";
-import { K0SmotronControlPlaneV1Beta2SpecServiceType } from "#imports/controlplane.cluster.x-k8s.io";
+import {
+  K0SmotronControlPlaneV1Beta2SpecServiceType,
+  type K0SmotronControlPlaneV1Beta2SpecTopologySpreadConstraints,
+} from "#imports/controlplane.cluster.x-k8s.io";
 import {
   DEFAULT_PRESTART_COMMANDS,
   renderK0sWorkerArgs,
@@ -22,6 +25,13 @@ export interface K0smotronClusterControlPlane {
   serviceType?: K0SmotronControlPlaneV1Beta2SpecServiceType;
   /** API Service annotations (hosting-cluster LB specifics, e.g. AWS NLB scheme). */
   serviceAnnotations?: Record<string, string>;
+  /** Requests/limits for the CP pods (scheduler-honest sizing on the hosting cluster). */
+  resources?: {
+    requests?: Record<string, string>;
+    limits?: Record<string, string>;
+  };
+  /** topologySpreadConstraints for the CP pods (e.g. one hosted CP per hosting node). */
+  topologySpreadConstraints?: K0SmotronControlPlaneV1Beta2SpecTopologySpreadConstraints[];
 }
 
 export interface K0smotronClusterConfig<M> {
@@ -115,6 +125,8 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
       persistence: this.config.controlPlane?.persistence,
       serviceType: this.config.controlPlane?.serviceType,
       serviceAnnotations: this.config.controlPlane?.serviceAnnotations,
+      resources: this.config.controlPlane?.resources,
+      topologySpreadConstraints: this.config.controlPlane?.topologySpreadConstraints,
     });
 
     // 4. Worker pools — per pool: infra machine template (provider) +

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
@@ -7,7 +7,40 @@ import {
   K0SmotronControlPlaneV1Beta2SpecPersistencePersistentVolumeClaimSpecResourcesRequests,
   K0SmotronControlPlaneV1Beta2SpecPatches,
   K0SmotronControlPlaneV1Beta2SpecPatchesPatchType,
+  K0SmotronControlPlaneV1Beta2SpecResources,
+  K0SmotronControlPlaneV1Beta2SpecResourcesLimits,
+  K0SmotronControlPlaneV1Beta2SpecResourcesRequests,
+  type K0SmotronControlPlaneV1Beta2SpecTopologySpreadConstraints,
 } from "#imports/controlplane.cluster.x-k8s.io";
+
+/** The generated Quantity wrappers serialize via `.value` — bare strings render null. */
+function toQuantities(resources: {
+  requests?: Record<string, string>;
+  limits?: Record<string, string>;
+}): K0SmotronControlPlaneV1Beta2SpecResources {
+  return {
+    ...(resources.requests
+      ? {
+          requests: Object.fromEntries(
+            Object.entries(resources.requests).map(([k, v]) => [
+              k,
+              K0SmotronControlPlaneV1Beta2SpecResourcesRequests.fromString(v),
+            ]),
+          ),
+        }
+      : {}),
+    ...(resources.limits
+      ? {
+          limits: Object.fromEntries(
+            Object.entries(resources.limits).map(([k, v]) => [
+              k,
+              K0SmotronControlPlaneV1Beta2SpecResourcesLimits.fromString(v),
+            ]),
+          ),
+        }
+      : {}),
+  };
+}
 
 /** Hosted-etcd persistence for the k0smotron control plane. */
 export type K0smotronControlPlanePersistence =
@@ -50,6 +83,20 @@ export interface K0smotronControlPlaneConfig {
    * NLB to "internal" and workers in another VPC cannot reach the CP.
    */
   serviceAnnotations?: Record<string, string>;
+  /**
+   * Requests/limits for the CP (kmc-*) pods. Without requests the scheduler
+   * bin-packs multiple hosted CPs onto one hosting node and saturates it.
+   */
+  resources?: {
+    requests?: Record<string, string>;
+    limits?: Record<string, string>;
+  };
+  /**
+   * topologySpreadConstraints for the CP pods — e.g. spread all
+   * `app.kubernetes.io/component: control-plane` pods across hostnames so two
+   * workload clusters' CPs never share a hosting node.
+   */
+  topologySpreadConstraints?: K0SmotronControlPlaneV1Beta2SpecTopologySpreadConstraints[];
 }
 
 /**
@@ -142,6 +189,10 @@ export class K0smotronControlPlane extends BaseConstruct<K0smotronControlPlaneCo
             K0SmotronControlPlaneV1Beta2SpecServiceType.LOAD_BALANCER,
         },
         ...(servicePatches.length ? { patches: servicePatches } : {}),
+        ...(this.config.resources ? { resources: toQuantities(this.config.resources) } : {}),
+        ...(this.config.topologySpreadConstraints
+          ? { topologySpreadConstraints: this.config.topologySpreadConstraints }
+          : {}),
       },
     });
   }


### PR DESCRIPTION
Hosted CP (kmc-*) pods run with no requests, so the hosting cluster's scheduler bin-packs multiple workload clusters' CPs onto one node and saturates it (observed on mgmt: cicd+stage CPs co-located on a node at 96% CPU → kubelet heartbeat misses → NodeNotReady flaps → API TLS timeouts + konnectivity drops). Exposes the CRD's `resources` and `topologySpreadConstraints` through `K0smotronControlPlane` and the `K0smotronCluster` controlPlane options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)