### PR TITLE
fix(dns): the upbound Eip CRD Kind is EIP, not Eip

### DIFF
--- a/packages/nebula/src/modules/infra/dns/eip-record.ts
+++ b/packages/nebula/src/modules/infra/dns/eip-record.ts
@@ -166,7 +166,7 @@ spec:
                       forProvider: {
                         manifest: {
                           apiVersion: "ec2.aws.upbound.io/v1beta1",
-                          kind: "Eip",
+                          kind: "EIP",
                           metadata: { name: "placeholder" },
                         },
                       },


### PR DESCRIPTION
spec.names.kind is EIP (all caps); the observe Object hit 'no matches for kind Eip'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)