### PR TITLE
feat(k0s): default the CNI to bundled Calico with WireGuard

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,6 +31,20 @@ landed alongside these changes; the items below are the **behavior-changing** on
 - **`confidential-containers` `tdx` shim default is now `false`** (was `true`).
   Intel TDX now opts in explicitly; AMD SEV-SNP remains the default. Callers that
   passed a `shims` object without an explicit `tdx` no longer pull `qemu-tdx`.
+- **k0s CNI now defaults to bundled Calico with WireGuard.** `K0sCluster`,
+  `AwsK0sCluster`, `K0smotronCluster` and `K0smotronControlPlane` default
+  `networkProvider` to `"calico"` (was `"kuberouter"` on the standalone-CP
+  constructs, hardcoded `"custom"` on the k0smotron ones) and `calico.wireguard`
+  to `true` (was `false`). A cluster therefore self-bootstraps with an encrypted
+  CNI before any pod schedules, and the AWS adapter opens the matching
+  `cniIngressRules` (UDP 4789 + 51820) — previously a caller relying on the
+  wireguard default got the k0s setting without the SG rule.
+  **The CNI provider is immutable after cluster creation** (k0s only supports
+  changing it via full redeployment), so any EXISTING cluster that relied on the
+  old defaults must pin them explicitly — `networkProvider: "kuberouter"`, or
+  `"custom"` where a separate CNI (e.g. the `Calico` Helm module) owns pod
+  networking — BEFORE re-rendering its manifests.
+
 - **AWS management-cluster NLB is internal by default.** `AwsK0sCluster` now
   defaults `controlPlaneLoadBalancerScheme` to `INTERNAL`, so the k0s API is not
   exposed to the internet (mTLS still guards it). Set it to

--- a/packages/nebula/src/modules/infra/aws/k0s-cluster.ts
+++ b/packages/nebula/src/modules/infra/aws/k0s-cluster.ts
@@ -135,9 +135,10 @@ export interface AwsK0sClusterConfig {
   controlPlaneLoadBalancerScheme?: AwsClusterV1Beta2SpecControlPlaneLoadBalancerScheme;
   /**
    * CNI for the embedded k0s ClusterConfig (`spec.network.provider`). Defaults to
-   * `"kuberouter"` (k0s's built-in CNI). Set to `"custom"` to make k0s install NO
-   * CNI, so a CNI is deployed separately (e.g. the `Calico` module owns pod
-   * networking + the encrypted node mesh).
+   * `"calico"` (k0s's bundled Calico), so the cluster self-bootstraps with a CNI
+   * up before any pod schedules. Set to `"custom"` to make k0s install NO CNI, so
+   * a CNI is deployed separately (e.g. the `Calico` module owns pod networking +
+   * the encrypted node mesh).
    * **Immutable at cluster creation**: switching the CNI on a running cluster is a
    * disruptive pod re-IP migration, so pick this on a FRESH bootstrap.
    */
@@ -145,10 +146,10 @@ export interface AwsK0sClusterConfig {
   /**
    * k0s-bundled Calico settings, emitted into `spec.network.calico` ONLY when
    * `networkProvider` is `"calico"`. Defaults to `mode: "vxlan"` (no BGP — works
-   * on any L2/L3 underlay incl. AWS). `wireguard: true` enables encrypted
+   * on any L2/L3 underlay incl. AWS) and `wireguard: true` (encrypted
    * node-to-node pod traffic — inert on a single node, active once there are
-   * multiple nodes. Set it at create so it's already in the cluster's k0s config
-   * when you scale (changing the k0sConfigSpec later rolls the control plane).
+   * multiple nodes). Both are baked in at create, since changing the
+   * k0sConfigSpec later rolls the control plane.
    */
   calico?: {
     wireguard?: boolean;
@@ -204,8 +205,16 @@ export class AwsK0sCluster extends BaseConstruct<AwsK0sClusterConfig> {
     const serviceCidr = this.config.serviceCidr ?? "10.96.0.0/12";
     const vpcCidr = this.config.vpcCidr ?? "10.0.0.0/16";
     const cp = this.config.controlPlane ?? {};
-    const networkProvider = this.config.networkProvider ?? "kuberouter";
-    const calico = this.config.calico ?? {};
+    const networkProvider = this.config.networkProvider ?? "calico";
+    // Resolve the Calico defaults ONCE: the same values feed the k0s
+    // ClusterConfig below AND the CAPA cniIngressRules, which would otherwise
+    // miss WireGuard's UDP 51820 whenever the caller relies on the default
+    // (silently dropping all cross-node pod traffic).
+    const calico = {
+      mode: this.config.calico?.mode ?? "vxlan",
+      wireguard: this.config.calico?.wireguard ?? true,
+      ...(this.config.calico?.mtu ? { mtu: this.config.calico.mtu } : {}),
+    };
     const nodeLocalLoadBalancing = this.config.nodeLocalLoadBalancing ?? {};
     const iamInstanceProfile =
       this.config.iamInstanceProfile ?? DEFAULT_NODE_INSTANCE_PROFILE;
@@ -299,8 +308,8 @@ export class AwsK0sCluster extends BaseConstruct<AwsK0sClusterConfig> {
           // so the real control plane matches the CAPI clusterNetwork above.
           // Without this, k0s falls back to its own defaults whenever a caller
           // overrides podCidr/serviceCidr. The CNI is selected by `networkProvider`
-          // ("kuberouter" default; "custom" makes k0s install NO CNI so the Calico
-          // module owns networking + the encrypted node mesh).
+          // ("calico" default — bundled, WireGuard on; "custom" makes k0s install
+          // NO CNI so the Calico module owns networking + the encrypted node mesh).
           k0S: {
             apiVersion: "k0s.k0sproject.io/v1beta1",
             kind: "ClusterConfig",
@@ -317,16 +326,8 @@ export class AwsK0sCluster extends BaseConstruct<AwsK0sClusterConfig> {
                   type: nodeLocalLoadBalancing.type ?? "EnvoyProxy",
                 },
                 // k0s-bundled Calico tuning (only meaningful for provider=calico):
-                // vxlan overlay (no BGP) + optional wireguard node-mesh encryption.
-                ...(networkProvider === "calico"
-                  ? {
-                      calico: {
-                        mode: calico.mode ?? "vxlan",
-                        wireguard: calico.wireguard ?? false,
-                        ...(calico.mtu ? { mtu: calico.mtu } : {}),
-                      },
-                    }
-                  : {}),
+                // vxlan overlay (no BGP) + wireguard node-mesh encryption.
+                ...(networkProvider === "calico" ? { calico } : {}),
                 podCIDR: podCidr,
                 serviceCIDR: serviceCidr,
               },

--- a/packages/nebula/src/modules/infra/k0s/cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/cluster.ts
@@ -131,12 +131,18 @@ export interface K0sClusterConfig<M> {
   /** Service CIDR (default "10.96.0.0/12"). */
   serviceCidr?: string;
   /**
-   * CNI for the embedded k0s ClusterConfig. Default "kuberouter" (k0s built-in).
-   * "custom" makes k0s install NO CNI so a CNI is deployed separately (e.g. the
-   * `Calico` module). Immutable at cluster creation.
+   * CNI for the embedded k0s ClusterConfig. Default "calico" (k0s's bundled
+   * Calico), so the cluster self-bootstraps with a CNI up before any pod
+   * schedules — no separate CNI deploy to sequence. "custom" makes k0s install
+   * NO CNI so a CNI is deployed separately (e.g. the `Calico` module).
+   * Immutable at cluster creation.
    */
   networkProvider?: "kuberouter" | "calico" | "custom";
-  /** k0s-bundled Calico settings (only meaningful when networkProvider="calico"). */
+  /**
+   * k0s-bundled Calico settings (only meaningful when networkProvider="calico").
+   * Defaults: `mode: "vxlan"`, `wireguard: true` (encrypted node-to-node pod
+   * traffic).
+   */
   calico?: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
   /**
    * Configure the kube-apiserver as an OIDC issuer for IRSA/WebIdentity.
@@ -206,8 +212,16 @@ export class K0sCluster<M> extends BaseConstruct<K0sClusterConfig<M>> {
     const k0sVersion = `${k8sVersion}+k0s.0`;
     const podCidr = this.config.podCidr ?? "10.244.0.0/16";
     const serviceCidr = this.config.serviceCidr ?? "10.96.0.0/12";
-    const networkProvider = this.config.networkProvider ?? "kuberouter";
-    const calico = this.config.calico ?? {};
+    const networkProvider = this.config.networkProvider ?? "calico";
+    // Resolve the Calico defaults ONCE: the same values feed the k0s
+    // ClusterConfig below AND the provider's node-to-node SG rules, which would
+    // otherwise miss WireGuard's UDP 51820 whenever the caller relies on the
+    // default (silently dropping all cross-node pod traffic).
+    const calico = {
+      mode: this.config.calico?.mode ?? "vxlan",
+      wireguard: this.config.calico?.wireguard ?? true,
+      ...(this.config.calico?.mtu ? { mtu: this.config.calico.mtu } : {}),
+    };
     const cp = this.config.controlPlane;
     const provider = this.config.provider;
 
@@ -274,15 +288,7 @@ export class K0sCluster<M> extends BaseConstruct<K0sClusterConfig<M>> {
             spec: {
               network: {
                 provider: networkProvider,
-                ...(networkProvider === "calico"
-                  ? {
-                      calico: {
-                        mode: calico.mode ?? "vxlan",
-                        wireguard: calico.wireguard ?? false,
-                        ...(calico.mtu ? { mtu: calico.mtu } : {}),
-                      },
-                    }
-                  : {}),
+                ...(networkProvider === "calico" ? { calico } : {}),
                 podCIDR: podCidr,
                 serviceCIDR: serviceCidr,
               },

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
@@ -45,6 +45,19 @@ export interface K0smotronClusterConfig<M> {
   podCidr?: string;
   /** Service CIDR (default "10.96.0.0/12"). */
   serviceCidr?: string;
+  /**
+   * CNI for the workload cluster. Default "calico" (k0s's bundled Calico,
+   * installed into the child cluster by the hosted CP). "custom" installs no CNI
+   * — workers stay NotReady until one is deployed separately (e.g. the `Calico`
+   * module), which also makes convergence depend on that deploy landing.
+   * **Immutable at cluster creation** (k0s: CNI changes need a full redeploy).
+   */
+  networkProvider?: "kuberouter" | "calico" | "custom";
+  /**
+   * k0s-bundled Calico settings (only meaningful when networkProvider="calico").
+   * Defaults: `mode: "vxlan"`, `wireguard: true`.
+   */
+  calico?: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
   /** Hosted control plane (K0smotronControlPlane pods on the hosting cluster). */
   controlPlane?: K0smotronClusterControlPlane;
   /** Worker pools keyed by pool name (each a MachineDeployment). */
@@ -64,8 +77,9 @@ export interface K0smotronClusterConfig<M> {
  * the workers carry a {@link K0sInfraProvider} `M`. The provider is told the CP is
  * hosted (`hostedControlPlane: true`) so it emits its infra cluster with the API
  * load balancer DISABLED — k0smotron exposes the API via a Service on the hosting
- * cluster, not via the workers' infra provider. CNI is "custom" (installed
- * separately into the workload cluster, e.g. the `Calico` module).
+ * cluster, not via the workers' infra provider. CNI defaults to k0s's bundled
+ * Calico (WireGuard on), installed into the workload cluster by the hosted CP;
+ * `networkProvider: "custom"` opts out and leaves it to a separate deploy.
  */
 export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>> {
   constructor(scope: Construct, id: string, config: K0smotronClusterConfig<M>) {
@@ -77,6 +91,14 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
     const k0sVersion = `${k8sVersion}+k0s.0`;
     const podCidr = this.config.podCidr ?? "10.244.0.0/16";
     const serviceCidr = this.config.serviceCidr ?? "10.96.0.0/12";
+    const networkProvider = this.config.networkProvider ?? "calico";
+    // Resolved once so the worker SG rules the provider emits match the
+    // transport the hosted CP actually configures (WireGuard needs UDP 51820).
+    const calico = {
+      mode: this.config.calico?.mode ?? "vxlan",
+      wireguard: this.config.calico?.wireguard ?? true,
+      ...(this.config.calico?.mtu ? { mtu: this.config.calico.mtu } : {}),
+    };
     const provider = this.config.provider;
 
     const clusterName = name;
@@ -105,13 +127,13 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
     });
 
     // 2. Infra cluster CR (AWSCluster/…) — CAPA owns the VPC/subnets/SGs; the API
-    //    load balancer is DISABLED (k0smotron exposes the API). networkProvider is
-    //    "custom" (a CNI is installed separately into the workload cluster).
+    //    load balancer is DISABLED (k0smotron exposes the API). networkProvider
+    //    is passed through so the provider opens the CNI's node-to-node transport.
     provider.emitInfraCluster(this, {
       clusterName,
       namespace,
-      networkProvider: "custom",
-      calico: {},
+      networkProvider,
+      calico,
       hostedControlPlane: true,
     });
 
@@ -122,6 +144,8 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
       k8sVersion,
       podCidr,
       serviceCidr,
+      networkProvider,
+      calico,
       persistence: this.config.controlPlane?.persistence,
       serviceType: this.config.controlPlane?.serviceType,
       serviceAnnotations: this.config.controlPlane?.serviceAnnotations,

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
@@ -66,6 +66,21 @@ export interface K0smotronControlPlaneConfig {
   podCidr?: string;
   /** Service CIDR (default "10.96.0.0/12"). */
   serviceCidr?: string;
+  /**
+   * CNI the hosted control plane installs into the WORKLOAD cluster. Default
+   * "calico" (k0s's bundled Calico): the CP's manifest applier writes it to the
+   * child API, so workers go Ready without waiting on a separate CNI deploy.
+   * "custom" installs NO CNI — workers stay NotReady until one is deployed into
+   * the workload cluster (e.g. the `Calico` module).
+   * **Immutable at cluster creation** — k0s only supports changing the CNI
+   * provider through a full cluster redeployment.
+   */
+  networkProvider?: "kuberouter" | "calico" | "custom";
+  /**
+   * k0s-bundled Calico settings (only emitted when networkProvider="calico").
+   * Defaults: `mode: "vxlan"`, `wireguard: true`.
+   */
+  calico?: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
   /** Hosted-etcd persistence (default emptyDir). */
   persistence?: K0smotronControlPlanePersistence;
   /**
@@ -122,6 +137,12 @@ export class K0smotronControlPlane extends BaseConstruct<K0smotronControlPlaneCo
     const version = `${k8sVersion}+k0s.0`;
     const podCidr = this.config.podCidr ?? "10.244.0.0/16";
     const serviceCidr = this.config.serviceCidr ?? "10.96.0.0/12";
+    const networkProvider = this.config.networkProvider ?? "calico";
+    const calico = {
+      mode: this.config.calico?.mode ?? "vxlan",
+      wireguard: this.config.calico?.wireguard ?? true,
+      ...(this.config.calico?.mtu ? { mtu: this.config.calico.mtu } : {}),
+    };
 
     const cpPersistence = this.config.persistence;
     const persistence: K0SmotronControlPlaneV1Beta2SpecPersistence =
@@ -174,9 +195,12 @@ export class K0smotronControlPlane extends BaseConstruct<K0smotronControlPlaneCo
           kind: "ClusterConfig",
           spec: {
             network: {
-              // CNI is installed separately (e.g. the Calico module) into the
-              // workload cluster; k0s installs no CNI.
-              provider: "custom",
+              // k0smotron merges this config untouched, and the CP pod runs a
+              // full k0s controller — so a bundled CNI ("calico"/"kuberouter")
+              // is applied to the child API by the CP's manifest applier.
+              // "custom" installs none, leaving the CNI to a separate deploy.
+              provider: networkProvider,
+              ...(networkProvider === "calico" ? { calico } : {}),
               podCIDR: podCidr,
               serviceCIDR: serviceCidr,
             },


### PR DESCRIPTION
k0s's bundled Calico installs at cluster boot, so a cluster converges with an encrypted CNI up before any pod schedules — no separate CNI deploy to sequence, no kubelet-path override, and one less Application per cluster. The mgmt cluster has run this configuration since bootstrap; make it the default everywhere instead of kuberouter (standalone CP) / custom (hosted).

K0smotronCluster and K0smotronControlPlane hardcoded provider "custom" and could not request a bundled CNI at all; both now take networkProvider + calico, and K0smotronCluster passes them to the infra provider so the worker SG rules match the transport the hosted CP configures.

Resolve the Calico defaults once per construct rather than at each use: the same values feed the k0s ClusterConfig and the CAPA cniIngressRules, and the SG side had no wireguard default — with wireguard now defaulting to true, a caller relying on the default would have gotten the k0s setting without UDP 51820 ingress, silently dropping all cross-node pod traffic.

The CNI provider is immutable after cluster creation (k0s supports changing it only via full redeployment), so existing clusters must pin their current provider before re-rendering; documented in UPGRADING.md.