### PR TITLE
feat(crossplane): function-auto-ready in XR pipelines

### DIFF
--- a/packages/nebula/src/modules/infra/dns/eip-record.ts
+++ b/packages/nebula/src/modules/infra/dns/eip-record.ts
@@ -186,7 +186,11 @@ spec:
                       fromFieldPath: "spec.kubeProviderConfigName",
                       toFieldPath: "spec.providerConfigRef.name",
                     },
-                  ],
+                    {
+            step: "auto-ready",
+            functionRef: { name: "function-auto-ready" },
+          },
+        ],
                 },
               ],
             },

--- a/packages/nebula/src/modules/k8s/argocd/argocd-cluster-sync.ts
+++ b/packages/nebula/src/modules/k8s/argocd/argocd-cluster-sync.ts
@@ -258,7 +258,11 @@ stringData:
                       fromFieldPath: "spec.kubeProviderConfigName",
                       toFieldPath: "spec.providerConfigRef.name",
                     },
-                  ],
+                    {
+            step: "auto-ready",
+            functionRef: { name: "function-auto-ready" },
+          },
+        ],
                 },
               ],
             },

--- a/packages/nebula/src/modules/k8s/crossplane/index.ts
+++ b/packages/nebula/src/modules/k8s/crossplane/index.ts
@@ -194,6 +194,18 @@ export class Crossplane extends HelmModule<CrossplaneConfig> {
       },
     );
 
+    // Derives XR Ready from composed-resource readiness. Without it, XRs from
+    // go-templating pipelines never leave Ready=False, which ArgoCD health
+    // renders as a permanently Degraded application (observed on the
+    // cluster-sync and eip-record XRs).
+    new FunctionV1Beta1(this, "function-auto-ready", {
+      metadata: { name: "function-auto-ready" },
+      spec: {
+        package:
+          "xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.4.2",
+      },
+    });
+
     // Install ArgoCD Provider if not explicitly disabled
     if (this.config.argoCdProvider !== false) {
       const opts = this.config.argoCdProvider ?? {};


### PR DESCRIPTION
Kills the permanent Ready=False / ArgoCD Degraded on cluster-sync + eip-record XRs.