### PR TITLE
fix(crossplane): auto-ready at pipeline level

### DIFF
--- a/packages/nebula/src/modules/infra/dns/eip-record.ts
+++ b/packages/nebula/src/modules/infra/dns/eip-record.ts
@@ -186,11 +186,7 @@ spec:
                       fromFieldPath: "spec.kubeProviderConfigName",
                       toFieldPath: "spec.providerConfigRef.name",
                     },
-                    {
-            step: "auto-ready",
-            functionRef: { name: "function-auto-ready" },
-          },
-        ],
+                  ],
                 },
               ],
             },
@@ -204,6 +200,10 @@ spec:
               source: "Inline",
               inline: { template: recordTemplate },
             },
+          },
+          {
+            step: "auto-ready",
+            functionRef: { name: "function-auto-ready" },
           },
         ],
       },

--- a/packages/nebula/src/modules/k8s/argocd/argocd-cluster-sync.ts
+++ b/packages/nebula/src/modules/k8s/argocd/argocd-cluster-sync.ts
@@ -258,11 +258,7 @@ stringData:
                       fromFieldPath: "spec.kubeProviderConfigName",
                       toFieldPath: "spec.providerConfigRef.name",
                     },
-                    {
-            step: "auto-ready",
-            functionRef: { name: "function-auto-ready" },
-          },
-        ],
+                  ],
                 },
               ],
             },
@@ -280,6 +276,10 @@ stringData:
                 template: secretTemplate,
               },
             },
+          },
+          {
+            step: "auto-ready",
+            functionRef: { name: "function-auto-ready" },
           },
         ],
       },


### PR DESCRIPTION
Repairs the misplaced insert from #44 (broke both composition reconciles).