### PR TITLE
fix(crossplane): report readiness for the composed ArgoCD cluster secret

### DIFF
--- a/packages/nebula/src/modules/k8s/argocd/argocd-cluster-sync.ts
+++ b/packages/nebula/src/modules/k8s/argocd/argocd-cluster-sync.ts
@@ -164,6 +164,11 @@ export class ArgoCdClusterSyncSetup extends Construct {
 
   private createComposition(): Composition {
     const secretTemplate = `
+{{- $obj := "" -}}
+{{- if .observed.resources -}}
+{{- $obj = index .observed.resources "kubeconfig-secret" -}}
+{{- end -}}
+{{- $rendered := and $obj $obj.resource $obj.resource.status $obj.resource.status.atProvider $obj.resource.status.atProvider.manifest -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -173,10 +178,9 @@ metadata:
     argocd.argoproj.io/secret-type: cluster
   annotations:
     gotemplating.fn.crossplane.io/composition-resource-name: argocd-cluster-secret
+    gotemplating.fn.crossplane.io/ready: "{{ if $rendered }}True{{ else }}False{{ end }}"
 type: Opaque
-{{- if .observed.resources }}
-{{- $obj := index .observed.resources "kubeconfig-secret" }}
-{{- if and $obj $obj.resource $obj.resource.status $obj.resource.status.atProvider $obj.resource.status.atProvider.manifest }}
+{{- if $rendered }}
 {{- $secretData := $obj.resource.status.atProvider.manifest.data }}
 {{- $kubeconfigB64 := index $secretData (.observed.composite.resource.spec.sourceSecretKey) }}
 {{- $kubeconfigYaml := $kubeconfigB64 | b64dec }}
@@ -195,7 +199,6 @@ stringData:
   server: {{ $serverUrl }}
   config: |
     {"tlsClientConfig":{"insecure":{{ $insecure }}{{- if not $insecure }},"caData":"{{ index $cluster "certificate-authority-data" }}"{{- end }},"certData":"{{ index $user "client-certificate-data" }}","keyData":"{{ index $user "client-key-data" }}"}}
-{{- end }}
 {{- end }}
 `.trim();
 


### PR DESCRIPTION
## Problem

Both `XArgoCdClusterSync` XRs reconcile cleanly (`Synced=True`) but sit at `Ready=False` forever:

```
NAME                 SYNCED   READY   COMPOSITION
cicd-argocd-sync     True     False   argocd-cluster-sync
stage-argocd-sync    True     False   argocd-cluster-sync
```

with `message: 'Unready resources: argocd-cluster-secret'`. ArgoCD therefore shows `cluster-stage` / `cluster-cicd` as Degraded even though the cluster secrets are complete and both clusters sync fine.

## Root cause

`function-auto-ready` **v0.4.2** (the deployed version) has no per-kind health checks — it marks a composed resource ready only via a `Ready` status condition. The per-kind table including "Secret — always ready if it exists" exists on the function's `main`, not in v0.4.2.

`argocd-cluster-secret` is a core `v1` Secret. It has no `status` at all, so it can never satisfy that check.

## Fix

Set readiness explicitly from the template using `gotemplating.fn.crossplane.io/ready`, which `function-auto-ready` honours ahead of its own check.

The observed-kubeconfig guard is hoisted into `$rendered` ahead of the metadata block so readiness is *conditional* rather than a blanket `"True"` — if the source kubeconfig isn't observable yet, the XR still reports unready instead of masking a real failure. That also collapses two nested `if`s into one.

## Verification

Template extracted from the source and rendered against four observed-state fixtures with Go 1.26 `text/template`:

| fixture | `ready` | `stringData` |
|---|---|---|
| no `observed.resources` at all | `"False"` | absent |
| `observed.resources` present, `kubeconfig-secret` key missing | `"False"` | absent |
| Object observed but `status` not yet populated | `"False"` | absent |
| fully observed kubeconfig | `"True"` | rendered |

No execute errors in any case (the `and` chain short-circuits), no stray leading blank lines from the new template actions, and the happy-path output is byte-identical to the previous template apart from the added annotation — so no churn on the live cluster secrets.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)