### PR TITLE
feat(k0s): full bundled-Calico config surface, one shared definition

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -1,5 +1,6 @@
 import { Construct } from "constructs";
 import { JsonPatch } from "cdk8s";
+import { ResolvedK0sCalico } from "../k0s/calico";
 import { ClusterV1Beta2 } from "#imports/cluster.x-k8s.io";
 import {
   AwsClusterV1Beta2,
@@ -181,7 +182,7 @@ export function emitAwsClusterCr(
     /** CNI selected in the k0s ClusterConfig. Used to emit matching AWS SG rules. */
     networkProvider?: "kuberouter" | "calico" | "custom";
     /** Bundled Calico transport settings (only used when networkProvider="calico"). */
-    calico?: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
+    calico?: ResolvedK0sCalico;
     /**
      * Cap the number of AZs CAPA spreads subnets across. CAPA creates one NAT
      * gateway (and thus one Elastic IP) per AZ, so on EIP-constrained accounts set
@@ -324,31 +325,47 @@ export function emitAwsClusterCr(
         // CAPA's Calico defaults only allow BGP (TCP 179) and IP-in-IP
         // (protocol 4). k0s defaults its bundled Calico to VXLAN and can enable
         // WireGuard, so those defaults silently drop all cross-node pod traffic
-        // on AWS. Make the selected transport explicit; CAPA applies these
-        // source-SG rules to both control-plane and worker node groups.
+        // on AWS. Emit rules for the transport actually selected, and ONLY that
+        // one — BGP and IP-in-IP are unused in vxlan mode.
+        //
+        // These are SOURCE-SG rules: CAPA gives them no CIDR field, so they only
+        // match traffic from an ENI in the same security group, i.e. inside the
+        // VPC. A cluster whose nodes advertise PUBLIC addresses (Calico
+        // autodetecting an EIP) sees all node-to-node traffic arrive via the
+        // internet gateway from a public source, where these never match — such
+        // a cluster must open the transport with CIDR-based
+        // `additionalNodeIngressRules` instead.
         ...(opts.networkProvider === "calico"
           ? {
               cni: {
                 cniIngressRules: [
-                  {
-                    description: "bgp (calico)",
-                    protocol: "tcp",
-                    fromPort: 179,
-                    toPort: 179,
-                  },
-                  {
-                    description: "IP-in-IP (calico)",
-                    protocol: "4",
-                    fromPort: -1,
-                    toPort: 65535,
-                  },
-                  ...((opts.calico?.mode ?? "vxlan") === "vxlan"
+                  ...(opts.calico?.mode === "bird"
+                    ? [
+                        {
+                          description: "bgp (calico)",
+                          protocol: "tcp",
+                          fromPort: 179,
+                          toPort: 179,
+                        },
+                      ]
+                    : []),
+                  ...(opts.calico?.mode === "ipip"
+                    ? [
+                        {
+                          description: "IP-in-IP (calico)",
+                          protocol: "4",
+                          fromPort: -1,
+                          toPort: 65535,
+                        },
+                      ]
+                    : []),
+                  ...(opts.calico?.mode === "vxlan"
                     ? [
                         {
                           description: "VXLAN (calico)",
                           protocol: "udp",
-                          fromPort: 4789,
-                          toPort: 4789,
+                          fromPort: opts.calico.vxlanPort,
+                          toPort: opts.calico.vxlanPort,
                         },
                       ]
                     : []),

--- a/packages/nebula/src/modules/infra/aws/k0s-cluster.ts
+++ b/packages/nebula/src/modules/infra/aws/k0s-cluster.ts
@@ -3,6 +3,11 @@ import { Construct } from "constructs";
 import { BaseConstruct } from "../../../core";
 import { DEFAULT_NODE_INSTANCE_PROFILE } from "./iam";
 import {
+  K0sCalicoConfig,
+  resolveK0sCalico,
+  renderK0sCalicoSpec,
+} from "../k0s/calico";
+import {
   DEFAULT_PRESTART_COMMANDS,
   emitClusterCr,
   emitAwsClusterCr,
@@ -151,11 +156,7 @@ export interface AwsK0sClusterConfig {
    * multiple nodes). Both are baked in at create, since changing the
    * k0sConfigSpec later rolls the control plane.
    */
-  calico?: {
-    wireguard?: boolean;
-    mode?: "vxlan" | "ipip" | "bird";
-    mtu?: number;
-  };
+  calico?: K0sCalicoConfig;
   /**
    * Keep node and pod traffic to the Kubernetes API on the node-local/private
    * path instead of hairpinning through the control-plane NLB. k0smotron uses
@@ -210,11 +211,7 @@ export class AwsK0sCluster extends BaseConstruct<AwsK0sClusterConfig> {
     // ClusterConfig below AND the CAPA cniIngressRules, which would otherwise
     // miss WireGuard's UDP 51820 whenever the caller relies on the default
     // (silently dropping all cross-node pod traffic).
-    const calico = {
-      mode: this.config.calico?.mode ?? "vxlan",
-      wireguard: this.config.calico?.wireguard ?? true,
-      ...(this.config.calico?.mtu ? { mtu: this.config.calico.mtu } : {}),
-    };
+    const calico = resolveK0sCalico(this.config.calico);
     const nodeLocalLoadBalancing = this.config.nodeLocalLoadBalancing ?? {};
     const iamInstanceProfile =
       this.config.iamInstanceProfile ?? DEFAULT_NODE_INSTANCE_PROFILE;
@@ -327,7 +324,9 @@ export class AwsK0sCluster extends BaseConstruct<AwsK0sClusterConfig> {
                 },
                 // k0s-bundled Calico tuning (only meaningful for provider=calico):
                 // vxlan overlay (no BGP) + wireguard node-mesh encryption.
-                ...(networkProvider === "calico" ? { calico } : {}),
+                ...(networkProvider === "calico"
+                  ? { calico: renderK0sCalicoSpec(calico) }
+                  : {}),
                 podCIDR: podCidr,
                 serviceCIDR: serviceCidr,
               },

--- a/packages/nebula/src/modules/infra/k0s/calico.ts
+++ b/packages/nebula/src/modules/infra/k0s/calico.ts
@@ -1,0 +1,105 @@
+/**
+ * k0s-bundled Calico configuration (`spec.network.calico`).
+ *
+ * One definition shared by every k0s cluster construct — the standalone-CP
+ * `K0sCluster`, the hosted-CP `K0smotronCluster`/`K0smotronControlPlane`, the
+ * legacy `AwsK0sCluster`, and the AWS provider's security-group derivation.
+ * Previously this type was inlined at six call sites and the defaults block
+ * copy-pasted at four, so widening the surface meant editing all of them.
+ *
+ * This is the CNI k0s installs itself, via the manifest applier. It is NOT the
+ * tigera-operator (`modules/k8s/calico`) — see that module's header for when
+ * each applies. The provider is immutable after cluster creation.
+ */
+
+/** k0s `spec.network.calico`. Every field optional; unset means k0s's default. */
+export interface K0sCalicoConfig {
+  /** Transport backend. Default "vxlan". */
+  mode?: "vxlan" | "ipip" | "bird";
+  /** Overlay scope. Ignored by k0s in vxlan mode. */
+  overlay?: "Always" | "CrossSubnet" | "Never";
+  /** WireGuard encryption for node-to-node pod traffic. Default true. */
+  wireguard?: boolean;
+  /** Overlay MTU. k0s binds this to VXLAN, IP-in-IP AND WireGuard together. */
+  mtu?: number;
+  /** VXLAN UDP port. Default 4789. */
+  vxlanPort?: number;
+  /** VXLAN VNI. Default 4096. */
+  vxlanVni?: number;
+  /**
+   * Calico `IP_AUTODETECTION_METHOD` — how each node picks its tunnel endpoint
+   * address: "first-found" | "kubernetes-internal-ip" | "can-reach=<ip>" |
+   * "interface=<regex>" | "skip-interface=<regex>" | "cidr=<cidr>,...".
+   * Unset means Calico's first-found, which on a node with several interfaces
+   * can select an address peers cannot reach.
+   */
+  ipAutodetectionMethod?: string;
+  /** IPv6 equivalent. k0s falls back to `ipAutodetectionMethod` when unset. */
+  ipV6AutodetectionMethod?: string;
+  /**
+   * Extra calico-node env vars. Felix reads env vars ABOVE every
+   * FelixConfiguration tier, so this is the escape hatch for any Felix setting
+   * k0s does not expose (e.g. FELIX_VXLANMTU / FELIX_WIREGUARDMTU separately).
+   */
+  envVars?: Record<string, string>;
+  /** Host path for the flex-volume driver. */
+  flexVolumeDriverPath?: string;
+}
+
+/**
+ * Calico config with the values needed outside the k0s ClusterConfig resolved.
+ * `mode`/`wireguard`/`vxlanPort` also drive the AWS provider's CNI ingress
+ * rules, so they must be resolved once and shared — otherwise a caller relying
+ * on a default gets a security group that does not match the transport actually
+ * in use (which silently drops all cross-node pod traffic).
+ */
+export interface ResolvedK0sCalico {
+  /** The caller's config verbatim; the renderer emits only what was set. */
+  readonly config: K0sCalicoConfig;
+  readonly mode: "vxlan" | "ipip" | "bird";
+  readonly wireguard: boolean;
+  readonly vxlanPort: number;
+}
+
+export function resolveK0sCalico(config: K0sCalicoConfig = {}): ResolvedK0sCalico {
+  return {
+    config,
+    mode: config.mode ?? "vxlan",
+    wireguard: config.wireguard ?? true,
+    vxlanPort: config.vxlanPort ?? 4789,
+  };
+}
+
+/**
+ * Render `spec.network.calico` for the embedded k0s ClusterConfig.
+ *
+ * Emits k0s's own key spelling — `vxlanVNI` and `ipV6AutodetectionMethod` are
+ * NOT the TS property names, and k0s ignores unknown keys silently, so a
+ * camelCased key would be a no-op that looks applied.
+ *
+ * Only `mode` and `wireguard` are emitted unconditionally; everything else
+ * appears only when the caller set it. `vxlanPort` in particular is resolved
+ * for the SG rules but left out of the render, so an existing cluster's
+ * k0sConfigSpec does not change (which would roll its control plane).
+ */
+export function renderK0sCalicoSpec(c: ResolvedK0sCalico): Record<string, unknown> {
+  const s = c.config;
+  return {
+    mode: c.mode,
+    wireguard: c.wireguard,
+    ...(s.mtu ? { mtu: s.mtu } : {}),
+    ...(s.overlay ? { overlay: s.overlay } : {}),
+    ...(s.vxlanPort ? { vxlanPort: s.vxlanPort } : {}),
+    ...(s.vxlanVni ? { vxlanVNI: s.vxlanVni } : {}),
+    ...(s.ipAutodetectionMethod
+      ? { ipAutodetectionMethod: s.ipAutodetectionMethod }
+      : {}),
+    ...(s.ipV6AutodetectionMethod
+      ? { ipV6AutodetectionMethod: s.ipV6AutodetectionMethod }
+      : {}),
+    ...(s.envVars ? { envVars: s.envVars } : {}),
+    ...(s.flexVolumeDriverPath
+      ? { flexVolumeDriverPath: s.flexVolumeDriverPath }
+      : {}),
+  };
+}

--- a/packages/nebula/src/modules/infra/k0s/cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/cluster.ts
@@ -3,6 +3,12 @@ import { BaseConstruct } from "../../../core";
 import { ClusterV1Beta2, MachineDeploymentV1Beta1 } from "#imports/cluster.x-k8s.io";
 import { K0sControlPlaneV1Beta2 } from "#imports/controlplane.cluster.x-k8s.io";
 import { K0sWorkerConfigTemplateV1Beta2 } from "#imports/bootstrap.cluster.x-k8s.io";
+import {
+  K0sCalicoConfig,
+  ResolvedK0sCalico,
+  resolveK0sCalico,
+  renderK0sCalicoSpec,
+} from "./calico";
 
 /**
  * A CAPI contract reference to a provider-specific infrastructure resource
@@ -74,7 +80,7 @@ export interface EmitInfraClusterCtx {
   /** CNI selected in the k0s ClusterConfig, so cloud providers can open its node-to-node transport. */
   networkProvider: "kuberouter" | "calico" | "custom";
   /** Bundled Calico transport settings (only meaningful for networkProvider="calico"). */
-  calico: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
+  calico: ResolvedK0sCalico;
   /**
    * Whether the control plane is HOSTED (k0smotron pods on a management cluster)
    * rather than standalone (on this cluster's own machines). When true the
@@ -143,7 +149,7 @@ export interface K0sClusterConfig<M> {
    * Defaults: `mode: "vxlan"`, `wireguard: true` (encrypted node-to-node pod
    * traffic).
    */
-  calico?: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
+  calico?: K0sCalicoConfig;
   /**
    * Configure the kube-apiserver as an OIDC issuer for IRSA/WebIdentity.
    * `issuerUrl` is the public HTTPS base URL hosting the discovery + JWKS.
@@ -217,11 +223,7 @@ export class K0sCluster<M> extends BaseConstruct<K0sClusterConfig<M>> {
     // ClusterConfig below AND the provider's node-to-node SG rules, which would
     // otherwise miss WireGuard's UDP 51820 whenever the caller relies on the
     // default (silently dropping all cross-node pod traffic).
-    const calico = {
-      mode: this.config.calico?.mode ?? "vxlan",
-      wireguard: this.config.calico?.wireguard ?? true,
-      ...(this.config.calico?.mtu ? { mtu: this.config.calico.mtu } : {}),
-    };
+    const calico = resolveK0sCalico(this.config.calico);
     const cp = this.config.controlPlane;
     const provider = this.config.provider;
 
@@ -288,7 +290,9 @@ export class K0sCluster<M> extends BaseConstruct<K0sClusterConfig<M>> {
             spec: {
               network: {
                 provider: networkProvider,
-                ...(networkProvider === "calico" ? { calico } : {}),
+                ...(networkProvider === "calico"
+                  ? { calico: renderK0sCalicoSpec(calico) }
+                  : {}),
                 podCIDR: podCidr,
                 serviceCIDR: serviceCidr,
               },

--- a/packages/nebula/src/modules/infra/k0s/index.ts
+++ b/packages/nebula/src/modules/infra/k0s/index.ts
@@ -10,6 +10,8 @@
  * `K0sCluster` is also repurposed by the k0rdent refactor as the emit engine that
  * generates the cluster-shape Helm chart a k0rdent `ClusterTemplate` wraps.
  */
+export { resolveK0sCalico, renderK0sCalicoSpec } from "./calico";
+export type { K0sCalicoConfig, ResolvedK0sCalico } from "./calico";
 export { K0sCluster, renderK0sWorkerArgs } from "./cluster";
 export type {
   K0sClusterConfig,

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
@@ -2,6 +2,7 @@ import { Construct } from "constructs";
 import { BaseConstruct } from "../../../core";
 import { ClusterV1Beta2, MachineDeploymentV1Beta1 } from "#imports/cluster.x-k8s.io";
 import { K0sWorkerConfigTemplateV1Beta2 } from "#imports/bootstrap.cluster.x-k8s.io";
+import { K0sCalicoConfig, resolveK0sCalico } from "./calico";
 import {
   K0SmotronControlPlaneV1Beta2SpecServiceType,
   type K0SmotronControlPlaneV1Beta2SpecTopologySpreadConstraints,
@@ -57,7 +58,7 @@ export interface K0smotronClusterConfig<M> {
    * k0s-bundled Calico settings (only meaningful when networkProvider="calico").
    * Defaults: `mode: "vxlan"`, `wireguard: true`.
    */
-  calico?: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
+  calico?: K0sCalicoConfig;
   /** Hosted control plane (K0smotronControlPlane pods on the hosting cluster). */
   controlPlane?: K0smotronClusterControlPlane;
   /** Worker pools keyed by pool name (each a MachineDeployment). */
@@ -94,11 +95,7 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
     const networkProvider = this.config.networkProvider ?? "calico";
     // Resolved once so the worker SG rules the provider emits match the
     // transport the hosted CP actually configures (WireGuard needs UDP 51820).
-    const calico = {
-      mode: this.config.calico?.mode ?? "vxlan",
-      wireguard: this.config.calico?.wireguard ?? true,
-      ...(this.config.calico?.mtu ? { mtu: this.config.calico.mtu } : {}),
-    };
+    const calico = resolveK0sCalico(this.config.calico);
     const provider = this.config.provider;
 
     const clusterName = name;
@@ -145,7 +142,7 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
       podCidr,
       serviceCidr,
       networkProvider,
-      calico,
+      calico: this.config.calico,
       persistence: this.config.controlPlane?.persistence,
       serviceType: this.config.controlPlane?.serviceType,
       serviceAnnotations: this.config.controlPlane?.serviceAnnotations,

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
@@ -1,6 +1,11 @@
 import { Construct } from "constructs";
 import { BaseConstruct } from "../../../core";
 import {
+  K0sCalicoConfig,
+  resolveK0sCalico,
+  renderK0sCalicoSpec,
+} from "./calico";
+import {
   K0smotronControlPlaneV1Beta2,
   K0SmotronControlPlaneV1Beta2SpecServiceType,
   K0SmotronControlPlaneV1Beta2SpecPersistence,
@@ -80,7 +85,7 @@ export interface K0smotronControlPlaneConfig {
    * k0s-bundled Calico settings (only emitted when networkProvider="calico").
    * Defaults: `mode: "vxlan"`, `wireguard: true`.
    */
-  calico?: { wireguard?: boolean; mode?: "vxlan" | "ipip" | "bird"; mtu?: number };
+  calico?: K0sCalicoConfig;
   /** Hosted-etcd persistence (default emptyDir). */
   persistence?: K0smotronControlPlanePersistence;
   /**
@@ -138,11 +143,7 @@ export class K0smotronControlPlane extends BaseConstruct<K0smotronControlPlaneCo
     const podCidr = this.config.podCidr ?? "10.244.0.0/16";
     const serviceCidr = this.config.serviceCidr ?? "10.96.0.0/12";
     const networkProvider = this.config.networkProvider ?? "calico";
-    const calico = {
-      mode: this.config.calico?.mode ?? "vxlan",
-      wireguard: this.config.calico?.wireguard ?? true,
-      ...(this.config.calico?.mtu ? { mtu: this.config.calico.mtu } : {}),
-    };
+    const calico = renderK0sCalicoSpec(resolveK0sCalico(this.config.calico));
 
     const cpPersistence = this.config.persistence;
     const persistence: K0SmotronControlPlaneV1Beta2SpecPersistence =

--- a/packages/nebula/src/modules/k8s/calico/index.ts
+++ b/packages/nebula/src/modules/k8s/calico/index.ts
@@ -1,6 +1,18 @@
 /**
  * Calico - CNI with WireGuard encryption for cross-node pod networking.
  *
+ * FOR NON-k0s / BYO CLUSTERS. On a k0s cluster prefer `networkProvider:"calico"`
+ * on `K0sCluster` / `K0smotronCluster` / `AwsK0sCluster`: the bundled CNI is up
+ * before the first pod schedules, so there is no separate Application to
+ * sequence, and it is configured through {@link K0sCalicoConfig} rather than an
+ * Installation CR. Running this module on a cluster whose k0s already manages
+ * Calico gives you two controllers fighting over the same objects — k0s
+ * stack-applies its manifests with prune, and the operator tries to take
+ * ownership of them. Use `networkProvider:"custom"` if you deploy this.
+ *
+ * The CNI provider is immutable after cluster creation, so this choice cannot
+ * be changed later without recreating the cluster.
+ *
  * Deploys the tigera-operator Helm chart which manages Calico components.
  * Optionally enables WireGuard encryption for pod-to-pod traffic, replacing
  * the need for manual WireGuard mesh tunnels in hybrid clusters.


### PR DESCRIPTION
Groundwork for moving every cluster onto k0s's bundled Calico (one CNI management surface instead of two: bundled on mgmt, tigera-operator on cicd/stage).

## Problem

`calico?: {wireguard?, mode?, mtu?}` was inlined at **six** call sites with the defaults block copy-pasted at **four**, so widening it meant editing all of them. It exposed 3 of k0s's 10 `spec.network.calico` fields.

## Change

One `K0sCalicoConfig` + `resolveK0sCalico()` + `renderK0sCalicoSpec()` in `infra/k0s/calico.ts`, wired through `K0sCluster`, `K0smotronCluster`, `K0smotronControlPlane`, `AwsK0sCluster` and `_shared.ts`. Adds `overlay`, `vxlanPort`, `vxlanVni`, `ipAutodetectionMethod`, `ipV6AutodetectionMethod`, `envVars`, `flexVolumeDriverPath`.

Two that carry real weight:

- **`ipAutodetectionMethod`** — a cluster whose nodes must advertise a non-default address (a public EIP for a cross-region mesh) previously had no declarative way to pin the tunnel endpoint. `kubernetes-internal-ip` derives it from the Node object.
- **`envVars`** — Felix reads env vars *above* every FelixConfiguration tier, so this is the escape hatch for any Felix setting k0s does not expose (e.g. sizing `FELIX_VXLANMTU` and `FELIX_WIREGUARDMTU` independently, which k0s binds together).

No CRD regeneration: `k0S`/`k0SConfig` are typed `any`.

### Two correctness details in the renderer

- **Key spelling.** It emits `vxlanVNI` and `ipV6AutodetectionMethod` literally. The config object is spread straight into `k0S`, and k0s ignores unknown keys silently — a camelCased key would be a no-op that looks applied.
- **Render neutrality.** Only `mode`/`wireguard` are unconditional; everything else appears only when set. `vxlanPort` is resolved for SG derivation but not rendered. So an existing cluster's `k0sConfigSpec` is unchanged and its control plane does not roll.

## cniIngressRules

Tightened to the transport actually in use — BGP 179 and IP-in-IP proto 4 were emitted unconditionally and are unused in `mode: vxlan`.

Also documented a trap worth knowing: CAPA's `CNIIngressRule` has no CIDR field (only `description`/`fromPort`/`protocol`/`toPort`), so CAPA scopes these by **source security group** — they only match traffic from an ENI in that SG, i.e. inside the VPC. A cluster whose nodes advertise public addresses sees all node-to-node traffic arrive via the IGW from a public source, where these never match; it must open the transport with CIDR-based `additionalNodeIngressRules`.

## Verification

- `tsc --noEmit` clean.
- **Render neutrality proven against the live mgmt cluster**: synthed `infra/cluster-api` before and after. `spec.network.calico` is byte-identical (`{mode: vxlan, wireguard: true}`) → no control-plane roll. The only diff is the two now-omitted unused CNI ingress rules.
- New props render correctly end-to-end: `{mode, wireguard, ipAutodetectionMethod, mtu}` all emitted under `spec.network.calico`.

The tigera `modules/k8s/calico` module is kept — it has live non-k0s consumers (`Platform.cni`, the CLI `init` scaffold, both examples) — with its docstring retargeted to "for non-k0s / BYO clusters" and a note that mixing it with k0s-managed Calico gives you two controllers fighting over the same objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)