### PR TITLE
fix(k0s): compose PooledRemoteMachine at its storage version (v1beta2)

### DIFF
--- a/packages/nebula/src/modules/infra/k0s/remote-worker.ts
+++ b/packages/nebula/src/modules/infra/k0s/remote-worker.ts
@@ -207,7 +207,10 @@ export class RemoteWorkerSetup extends Construct {
                 {
                   name: "pooled-machine",
                   base: {
-                    apiVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+                    // v1beta2 = the storage version. Composing the non-storage
+                    // version makes every read-back a converted object that
+                    // never matches what was applied (permanent drift).
+                    apiVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
                     kind: "PooledRemoteMachine",
                     metadata: { name: "placeholder", namespace: "default" },
                     spec: {


### PR DESCRIPTION
Follow-up to #48. v1beta2 is the storage version on the target cluster; composing v1beta1 makes every read-back a converted object that never matches what was applied — permanent drift (same class as the MachineHealthCheck v1beta2 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)