### PR TITLE
fix(k0s): grant crossplane RBAC on pooledremotemachines

### DIFF
--- a/packages/nebula/src/modules/infra/k0s/remote-worker.ts
+++ b/packages/nebula/src/modules/infra/k0s/remote-worker.ts
@@ -72,6 +72,26 @@ export class RemoteWorkerSetup extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
+    // Crossplane composes the PooledRemoteMachine DIRECTLY (no provider), so
+    // its own service account needs RBAC on the kind. The rbac-manager
+    // aggregates any ClusterRole carrying this label into crossplane's role —
+    // without it every compose attempt is denied at apply time.
+    new ApiObject(this, "crossplane-rbac", {
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      kind: "ClusterRole",
+      metadata: {
+        name: "crossplane:aggregate:remote-worker",
+        labels: { "rbac.crossplane.io/aggregate-to-crossplane": "true" },
+      },
+      rules: [
+        {
+          apiGroups: ["infrastructure.cluster.x-k8s.io"],
+          resources: ["pooledremotemachines", "pooledremotemachines/status"],
+          verbs: ["get", "list", "watch", "create", "update", "patch", "delete"],
+        },
+      ],
+    });
+
     this.xrd = new CompositeResourceDefinitionV2(this, "xrd", {
       metadata: {
         name: "xremoteworkers.nebula.io",


### PR DESCRIPTION
Live-observed on the stage rebuild: `User "system:serviceaccount:crossplane-system:crossplane" cannot patch resource "pooledremotemachines"`. The composition composes the kind directly, so crossplane's SA needs the rights; the rbac-manager aggregates any ClusterRole labeled `rbac.crossplane.io/aggregate-to-crossplane`. Shipped inside `RemoteWorkerSetup` so the plugin stays self-contained.

Everything upstream of the denial worked as designed: the Required-policy gate composed nothing until the Eip address landed, then the apply was attempted with the correct address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)