### PR TITLE
feat: CAPA ExternalResourceGC option + provider-aws patch bump

### DIFF
--- a/packages/nebula/src/modules/k8s/cluster-api-operator/index.ts
+++ b/packages/nebula/src/modules/k8s/cluster-api-operator/index.ts
@@ -120,6 +120,16 @@ export interface ClusterApiOperatorAwsConfig {
    * @default false
    */
   keyless?: boolean;
+  /**
+   * Enable CAPA's ExternalResourceGC feature gate: on cluster deletion, CAPA
+   * garbage-collects the AWS resources workload-cluster controllers created in
+   * the cluster's VPC (LB-controller NLBs/target groups, CCM security groups)
+   * that otherwise orphan and block the VPC teardown with DependencyViolation
+   * — observed live on the stage rebuild (leaked ingress NLB + two k8s-traffic
+   * SGs needed hand deletion before the IGW would detach).
+   * @default false
+   */
+  externalResourceGC?: boolean;
 }
 
 export interface ClusterApiOperatorConfig {
@@ -250,6 +260,9 @@ export class ClusterApiOperator extends HelmModule<ClusterApiOperatorConfig> {
           name: awsSecretName,
           namespace: awsSecretNamespace,
         },
+        ...(this.config.aws.externalResourceGC
+          ? { manager: { featureGates: { ExternalResourceGC: true } } }
+          : {}),
       };
     }
 

--- a/packages/nebula/src/modules/providers/aws.ts
+++ b/packages/nebula/src/modules/providers/aws.ts
@@ -61,7 +61,7 @@ export type AwsProviderFamily =
 export interface AwsProviderConfig {
   /** Provider name prefix (default: 'provider-aws') */
   name?: string;
-  /** Provider version (default: 'v2.6.0', matching the imported CRDs) */
+  /** Provider version (default: 'v2.6.2'; CRD imports generated at v2.6.0 — patch releases keep the schema) */
   version?: string;
   /** ProviderConfig name (default: 'default') */
   providerConfigName?: string;
@@ -103,7 +103,7 @@ export class AwsProvider extends Construct {
     super(scope, id);
 
     const providerNamePrefix = config.name ?? "provider-aws";
-    const providerVersion = config.version ?? "v2.6.0";
+    const providerVersion = config.version ?? "v2.6.2";
     const providerConfigName = config.providerConfigName ?? "default";
 
     // Default families needed for the infra/aws module (networking + IAM)


### PR DESCRIPTION
From the stage-rebuild retro ("is the code self-sufficient?"). Two of the four convergence gaps get durable fixes here:

1. **`externalResourceGC`** on the CAPA config — enables the `ExternalResourceGC` feature gate through the provider `manager.featureGates`. Cluster deletion then GCs the workload-created NLBs/target-groups/SGs that otherwise block VPC teardown with `DependencyViolation` (observed live: leaked ingress NLB + 2 SGs needed hand deletion).
2. **provider-aws v2.6.0 → v2.6.2** — the EC2 provider wedged silently (acknowledged MR deletes without touching AWS → zombie instances). A patch bump isn't a proven fix, but two patches behind a provider that just failed silently is the wrong side of the bet. Explicitly *not* claimed: the replacement-refusal class (`userDataReplaceOnChange`) — that's upjet by design.

The other two gaps land in DevOps: convergence alerting (ksm customResourceState + provider-liveness rules) and the authorized_keys ordering fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)