### PR TITLE
feat(aws,k0s): IPv6 dual-stack plumbing — on-link public node identity

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -179,6 +179,8 @@ export function emitAwsClusterCr(
      */
     loadBalancerScheme?: AwsClusterV1Beta2SpecControlPlaneLoadBalancerScheme;
     vpcCidr: string;
+    /** Request an Amazon-provided IPv6 GUA block on the VPC (dual-stack subnets). */
+    ipv6?: boolean;
     /** CNI selected in the k0s ClusterConfig. Used to emit matching AWS SG rules. */
     networkProvider?: "kuberouter" | "calico" | "custom";
     /** Bundled Calico transport settings (only used when networkProvider="calico"). */
@@ -314,6 +316,12 @@ export function emitAwsClusterCr(
       network: {
         vpc: {
           cidrBlock: opts.vpcCidr,
+          // Amazon-provided IPv6 GUA block for the VPC. Unlike public IPv4
+          // (1:1 NAT at the IGW - the instance never carries the address),
+          // IPv6 addresses are configured ON the instance interface and are
+          // globally routable, so self-detecting components (kubelet, Calico)
+          // find a real public address with no alias/node-ip emulation.
+          ...(opts.ipv6 ? { ipv6: {} } : {}),
           // One NAT gateway/EIP per AZ — cap AZs on EIP-constrained accounts.
           ...(opts.availabilityZoneUsageLimit
             ? {

--- a/packages/nebula/src/modules/infra/aws/k0s-provider.ts
+++ b/packages/nebula/src/modules/infra/aws/k0s-provider.ts
@@ -47,6 +47,8 @@ export interface AwsMachineSpec {
 
 /** Cluster-level AWS configuration for {@link AwsK0sProvider}. */
 export interface AwsK0sProviderConfig {
+  /** Amazon-provided IPv6 GUA block on the VPC (dual-stack subnets). */
+  ipv6?: boolean;
   /** AWS region. */
   region: string;
   /** VPC CIDR CAPA will create (default "10.0.0.0/16"). */
@@ -132,6 +134,7 @@ export class AwsK0sProvider implements K0sInfraProvider<AwsMachineSpec> {
           }),
       vpcCidr: this.config.vpcCidr ?? "10.0.0.0/16",
       networkProvider: ctx.networkProvider,
+      ipv6: this.config.ipv6,
       calico: ctx.calico,
       availabilityZoneUsageLimit: this.config.availabilityZoneUsageLimit,
       secondaryCidrBlocks: this.config.secondaryCidrBlocks,

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
@@ -59,6 +59,13 @@ export interface K0smotronClusterConfig<M> {
    * Defaults: `mode: "vxlan"`, `wireguard: true`.
    */
   calico?: K0sCalicoConfig;
+  /**
+   * Dual-stack: adds an IPv6 pod/service CIDR pair to the k0s network config.
+   * With an on-link IPv6 GUA on the nodes (AwsK0sProviderConfig.ipv6), the
+   * cluster's node identity can be a real public address with no NAT emulation.
+   * Per k0s docs, bundled Calico dual-stack requires mode "bird".
+   */
+  dualStack?: { ipv6PodCidr: string; ipv6ServiceCidr: string };
   /** Hosted control plane (K0smotronControlPlane pods on the hosting cluster). */
   controlPlane?: K0smotronClusterControlPlane;
   /** Worker pools keyed by pool name (each a MachineDeployment). */
@@ -143,6 +150,7 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
       serviceCidr,
       networkProvider,
       calico: this.config.calico,
+      dualStack: this.config.dualStack,
       persistence: this.config.controlPlane?.persistence,
       serviceType: this.config.controlPlane?.serviceType,
       serviceAnnotations: this.config.controlPlane?.serviceAnnotations,

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-control-plane.ts
@@ -86,6 +86,13 @@ export interface K0smotronControlPlaneConfig {
    * Defaults: `mode: "vxlan"`, `wireguard: true`.
    */
   calico?: K0sCalicoConfig;
+  /**
+   * Dual-stack: adds an IPv6 pod/service CIDR pair to the k0s network config.
+   * With an on-link IPv6 GUA on the nodes (AwsK0sProviderConfig.ipv6), the
+   * cluster's node identity can be a real public address with no NAT emulation.
+   * Per k0s docs, bundled Calico dual-stack requires mode "bird".
+   */
+  dualStack?: { ipv6PodCidr: string; ipv6ServiceCidr: string };
   /** Hosted-etcd persistence (default emptyDir). */
   persistence?: K0smotronControlPlanePersistence;
   /**
@@ -204,6 +211,15 @@ export class K0smotronControlPlane extends BaseConstruct<K0smotronControlPlaneCo
               ...(networkProvider === "calico" ? { calico } : {}),
               podCIDR: podCidr,
               serviceCIDR: serviceCidr,
+              ...(this.config.dualStack
+                ? {
+                    dualStack: {
+                      enabled: true,
+                      IPv6podCIDR: this.config.dualStack.ipv6PodCidr,
+                      IPv6serviceCIDR: this.config.dualStack.ipv6ServiceCidr,
+                    },
+                  }
+                : {}),
             },
           },
         },


### PR DESCRIPTION
Verified against AWS VPC docs: public IPv4 is 1:1 NAT at the IGW ("your instance is only aware of the private IP address space") — the root fact behind every public-identity emulation hack. IPv6 GUAs are on-interface and "public by default", so v6 identity needs no emulation, and it stays provider-agnostic (v6 is on-link on bare metal too).

Adds opt-in plumbing only: `AwsK0sProviderConfig.ipv6` → `vpc.ipv6: {}` (Amazon GUA block), and `dualStack {ipv6PodCidr, ipv6ServiceCidr}` → k0s `spec.network.dualStack`. First consumer: the cicd rehearsal.

Known unknowns the experiment must answer: CAPA v6 completeness for **unmanaged** clusters, and k0s's `mode: bird` requirement for dual-stack Calico (doc note predates Calico's v6 VXLAN; `envVars` can force `CALICO_IPV6POOL_VXLAN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)