### PR TITLE
fix(aws): open WireGuard v6 (51821) in cniIngressRules

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -385,6 +385,17 @@ export function emitAwsClusterCr(
                           fromPort: 51820,
                           toPort: 51820,
                         },
+                        // Felix runs the IPv6 WireGuard tunnel on its own port
+                        // (wireguardListeningPortV6, default 51821). Without it
+                        // a dual-stack cluster's v6 handshakes silently drop:
+                        // wg-v6.cali up, peers configured, 100% packet loss
+                        // (observed on the cicd dual-stack experiment).
+                        {
+                          description: "WireGuard v6 (calico)",
+                          protocol: "udp",
+                          fromPort: 51821,
+                          toPort: 51821,
+                        },
                       ]
                     : []),
                 ],


### PR DESCRIPTION
Found live on the cicd dual-stack experiment: felix's IPv6 WireGuard listens on its own port (`wireguardListeningPortV6`, default 51821). With only 51820 open, `wg-v6.cali` comes up, peers get configured, and every v6 handshake silently drops — 100% pod-to-pod v6 loss while v4 WG works. One rule fixes gate 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)