### PR TITLE
fix(aws): deterministic composed-Subnet name in DualStackSubnet

### DIFF
--- a/packages/nebula/src/modules/infra/aws/dualstack-subnet.ts
+++ b/packages/nebula/src/modules/infra/aws/dualstack-subnet.ts
@@ -171,6 +171,15 @@ export class DualStackSubnetSetup extends Construct {
                     },
                   },
                   patches: [
+                    // Deterministic MR name (== the XR name) so git-side
+                    // resources can reference the subnet with a plain
+                    // subnetIdRef {name} — composed resources otherwise get
+                    // generated names no static manifest can point at.
+                    {
+                      type: "FromCompositeFieldPath",
+                      fromFieldPath: "metadata.name",
+                      toFieldPath: "metadata.name",
+                    },
                     // The runtime-derived piece: the VPC's Amazon-assigned /56
                     // narrowed to this subnet's /64. Required-policy gates the
                     // subnet until the VPC reports its block.


### PR DESCRIPTION
Follow-up to #54: composed resources get generated names, but git-side `RouteTableAssociation.subnetIdRef` references by name. Patch `metadata.name` from the XR — same pattern as PooledRemoteMachine in #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)