### PR TITLE
fix(k0s): v2 XRs nest compositionRef under spec.crossplane

### DIFF
--- a/packages/nebula/src/modules/infra/k0s/worker.ts
+++ b/packages/nebula/src/modules/infra/k0s/worker.ts
@@ -527,8 +527,12 @@ export class Worker extends Construct {
       kind: "XWorker",
       metadata: { name: id },
       spec: {
-        compositionRef: {
-          name: config.dataVolumeName ? "worker" : "worker-basic",
+        // v2 XRD: machinery fields nest under spec.crossplane — a top-level
+        // compositionRef is silently pruned by the structural schema.
+        crossplane: {
+          compositionRef: {
+            name: config.dataVolumeName ? "worker" : "worker-basic",
+          },
         },
         eipName: config.eipName,
         instanceName: config.instanceName,


### PR DESCRIPTION
Top-level `spec.compositionRef` is silently pruned by the v2 XRD structural schema — observed live: ref empty on all five data-less XRs, merge patches no-op ("no change"), XRs stuck on the default composition. `spec.crossplane.compositionRef` works (canary flipped Ready=True in one reconcile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)