### PR TITLE
feat(argocd): recursive-ownership discovery (cluster-dirs + single-cluster modes)

### DIFF
--- a/packages/nebula/src/modules/k8s/argocd/app-tier.ts
+++ b/packages/nebula/src/modules/k8s/argocd/app-tier.ts
@@ -238,6 +238,9 @@ export interface ArgoCdAppTierClustersDiscovery {
    * management cluster with the `capi` preset.
    */
   mode: "clusters";
+  /** Cluster directories to skip (e.g. a co-located registry-tier dir like
+   *  `clusters/mgmt` that owns its own Applications). */
+  exclude?: string[];
   /** Filesystem directory to scan at synth time */
   dir: string;
   /** Repo directory the tree lives under (defaults to basename(dir)) */
@@ -431,6 +434,7 @@ export class ArgoCdAppTier extends BaseConstruct<ArgoCdAppTierConfig> {
       : undefined;
 
     for (const cluster of listDirs(discovery.dir)) {
+      if (discovery.exclude?.includes(cluster)) continue;
       const labels = { "nebula/tier": tier, "nebula/env": cluster };
       for (const mod of listDirs(join(discovery.dir, cluster))) {
         if (discovery.clusterApp && mod === clusterSubdir) {


### PR DESCRIPTION
Grew from the one-field exclude into the real fix. The recursion rule: **each directory level is owned by exactly one `index.ts`, and discovery never descends past a directory that has its own.**

- `cluster-dirs`: one-level walker — each `clusters/<name>/` becomes a single app-of-apps `<name>-apps` rendered from that directory. It knows nothing about what's inside.
- `cluster`: the per-cluster service walk rooted at ONE cluster's own dir (`<clusterName>-<svc>`, destination `{name}`, `cluster/` capi special-case) — identical naming to the two-level clusters mode, minus the sibling knowledge.
- The `exclude` field from the first commit stays (still useful for transitional trees) but the DevOps refactor no longer needs it: mgmt is just another cluster whose inner index.ts holds a dependency-ordered registry instead of a subdir walk.

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)