### PR TITLE
feat(k8s): mesh-scrape helpers + CorednsV6Face

### DIFF
--- a/packages/nebula/src/modules/k8s/coredns-v6-face/index.ts
+++ b/packages/nebula/src/modules/k8s/coredns-v6-face/index.ts
@@ -1,0 +1,56 @@
+/**
+ * The IPv6 face of CoreDNS for a k0s dual-stack cluster.
+ *
+ * k0s derives the kube-dns ClusterIP from the PRIMARY service CIDR, which k0s
+ * pins to IPv4 (dual-stack is v4-primary by validation, and the primary
+ * family cannot be flipped — verified empirically against v1.33/v1.34).
+ * Cross-region pods reaching a v4 ClusterIP get DNAT'd to a v4 CoreDNS pod
+ * IP — private, unroutable across regions once node identity is on-link
+ * (GUA + private v4). This Service is the same CoreDNS pods behind a v6
+ * ClusterIP: kube-proxy DNATs to the pods' v6 addresses and the query rides
+ * WireGuard-v6 between on-link GUAs.
+ *
+ * The ClusterIP is static: kubelet needs a literal address for
+ * `--cluster-dns` (see AwsWorkerFleetOptions.clusterDns), and DNS ClusterIPs
+ * are conventionally pinned — 10.96.0.10 is k0s's own such constant.
+ */
+import { Construct } from "constructs";
+import { ApiObject } from "cdk8s";
+
+export interface CorednsV6FaceOptions {
+  /** Static v6 ClusterIP inside the cluster's v6 service CIDR, e.g.
+   *  "fd01::53" under the conventional fd01::/108. */
+  clusterIp: string;
+  /** CoreDNS namespace (default "kube-system"). */
+  namespace?: string;
+  /** Service name (default "coredns-v6"). */
+  name?: string;
+  /** CoreDNS pod selector (default k0s's `k8s-app: kube-dns`). */
+  selector?: Record<string, string>;
+}
+
+export class CorednsV6Face extends Construct {
+  constructor(scope: Construct, id: string, options: CorednsV6FaceOptions) {
+    super(scope, id);
+    const name = options.name ?? "coredns-v6";
+    new ApiObject(this, "service", {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        name,
+        namespace: options.namespace ?? "kube-system",
+        labels: { "k8s-app": name },
+      },
+      spec: {
+        selector: options.selector ?? { "k8s-app": "kube-dns" },
+        ipFamilies: ["IPv6"],
+        ipFamilyPolicy: "SingleStack",
+        clusterIP: options.clusterIp,
+        ports: [
+          { name: "dns", port: 53, protocol: "UDP", targetPort: 53 },
+          { name: "dns-tcp", port: 53, protocol: "TCP", targetPort: 53 },
+        ],
+      },
+    });
+  }
+}

--- a/packages/nebula/src/modules/k8s/index.ts
+++ b/packages/nebula/src/modules/k8s/index.ts
@@ -259,6 +259,18 @@ export { ImagePullSecret } from "./image-pull-secret";
 export type { ImagePullSecretConfig } from "./image-pull-secret";
 
 export { Calico } from "./calico";
+export { CorednsV6Face } from "./coredns-v6-face";
+export type { CorednsV6FaceOptions } from "./coredns-v6-face";
+export {
+  meshAddress,
+  meshMonitorValues,
+  KEEP_METRICS_PATH,
+  MeshKubeProxyServiceMonitor,
+} from "./mesh-scrape";
+export type {
+  MeshFamily,
+  MeshKubeProxyServiceMonitorOptions,
+} from "./mesh-scrape";
 export {
   CrossplaneObservability,
   kubeStateMetricsValues,

--- a/packages/nebula/src/modules/k8s/mesh-scrape/index.ts
+++ b/packages/nebula/src/modules/k8s/mesh-scrape/index.ts
@@ -1,0 +1,131 @@
+/**
+ * Scrape host-network targets over the WireGuard mesh instead of the public
+ * internet.
+ *
+ * Calico gives each node a `wireguard.cali` / `wg-v6.cali` address from the
+ * pod CIDR and publishes it on the Node object. An exporter bound to 0.0.0.0
+ * in the host netns answers on it, and pod -> that address is tunnelled. So
+ * retargeting the scrape there moves it onto the mesh — without moving the
+ * exporter itself off the host network, which node_exporter does not support
+ * (/proc/net is netns-scoped, so a pod-network exporter reports its own veth;
+ * upstream closed this won't-fix and documents host network as the supported
+ * configuration).
+ *
+ * Requires `attachMetadata: { node: true }` on the monitor so node
+ * annotations are available as relabel sources (Prometheus >= 2.37).
+ *
+ * Fail-visible by construction: a node whose WireGuard never came up has no
+ * annotation, the regex does not match, `__address__` stays the discovered
+ * address, and the scrape fails -> TargetDown. "WireGuard is broken on node
+ * X" becomes an alert rather than a silent fallback to cleartext.
+ */
+import { Construct } from "constructs";
+import { ApiObject } from "cdk8s";
+
+export type MeshFamily = "IPv6" | "IPv4";
+
+const WG_ADDR_LABEL: Record<MeshFamily, string> = {
+  IPv6: "__meta_kubernetes_node_annotation_projectcalico_org_IPv6WireguardInterfaceAddr",
+  IPv4: "__meta_kubernetes_node_annotation_projectcalico_org_IPv4WireguardInterfaceAddr",
+};
+
+/** Relabeling that retargets `__address__` onto the node's WireGuard mesh
+ *  address (default the v6 tunnel; v6 literals are bracketed). */
+export const meshAddress = (port: number, family: MeshFamily = "IPv6") => [
+  {
+    action: "replace",
+    sourceLabels: [WG_ADDR_LABEL[family]],
+    regex: "(.+)",
+    replacement: family === "IPv6" ? `[$1]:${port}` : `$1:${port}`,
+    targetLabel: "__address__",
+  },
+];
+
+/** kube-prometheus-stack's kubelet ServiceMonitor relabels the metrics path
+ *  onto a label; preserve that when overriding the endpoint's relabelings. */
+export const KEEP_METRICS_PATH = {
+  action: "replace",
+  sourceLabels: ["__metrics_path__"],
+  targetLabel: "metrics_path",
+};
+
+/**
+ * kube-prometheus-stack values fragment putting the chart-owned host-network
+ * monitors (node-exporter, kubelet) on the mesh, and disabling the chart's
+ * kube-proxy monitor — its template has no attachMetadata support, so the CR
+ * is owned by {@link MeshKubeProxyServiceMonitor} instead.
+ */
+export function meshMonitorValues(
+  family: MeshFamily = "IPv6",
+): Record<string, unknown> {
+  return {
+    "prometheus-node-exporter": {
+      prometheus: {
+        monitor: {
+          attachMetadata: { node: true },
+          relabelings: meshAddress(9100, family),
+        },
+      },
+    },
+    kubelet: {
+      serviceMonitor: {
+        attachMetadata: { node: true },
+        relabelings: [KEEP_METRICS_PATH, ...meshAddress(10250, family)],
+        cAdvisorRelabelings: [KEEP_METRICS_PATH, ...meshAddress(10250, family)],
+        probesRelabelings: [KEEP_METRICS_PATH, ...meshAddress(10250, family)],
+      },
+    },
+    kubeProxy: { serviceMonitor: { enabled: false } },
+  };
+}
+
+export interface MeshKubeProxyServiceMonitorOptions {
+  /** monitoring namespace the CR lands in. */
+  namespace: string;
+  /** metadata.name of the ServiceMonitor. */
+  name: string;
+  /** kube-prometheus-stack release name (the chart's Service carries it in
+   *  its labels; default "prometheus"). */
+  releaseName?: string;
+  family?: MeshFamily;
+}
+
+/**
+ * kube-proxy ServiceMonitor, replacing the chart's. Identical to what the
+ * chart renders (same selector, namespaceSelector, port and bearer token)
+ * plus the attachMetadata + mesh relabeling the template does not support —
+ * this is what takes the last plaintext exporter off the public path.
+ */
+export class MeshKubeProxyServiceMonitor extends Construct {
+  constructor(
+    scope: Construct,
+    id: string,
+    options: MeshKubeProxyServiceMonitorOptions,
+  ) {
+    super(scope, id);
+    new ApiObject(this, "servicemonitor", {
+      apiVersion: "monitoring.coreos.com/v1",
+      kind: "ServiceMonitor",
+      metadata: { name: options.name, namespace: options.namespace },
+      spec: {
+        jobLabel: "jobLabel",
+        namespaceSelector: { matchNames: ["kube-system"] },
+        selector: {
+          matchLabels: {
+            app: "kube-prometheus-stack-kube-proxy",
+            release: options.releaseName ?? "prometheus",
+          },
+        },
+        attachMetadata: { node: true },
+        endpoints: [
+          {
+            port: "http-metrics",
+            bearerTokenFile:
+              "/var/run/secrets/kubernetes.io/serviceaccount/token",
+            relabelings: meshAddress(10249, options.family ?? "IPv6"),
+          },
+        ],
+      },
+    });
+  }
+}


### PR DESCRIPTION
DRY Tier 1.3 + 1.4, closing the extraction list:\n\n**mesh-scrape** — `meshAddress(port, family)` (v6 default with bracketed literals, v4 option for other estates), `KEEP_METRICS_PATH`, `meshMonitorValues(family)` (node-exporter + kubelet onto the mesh, chart kube-proxy monitor disabled), and `MeshKubeProxyServiceMonitor` (chart-identical CR plus the attachMetadata the template can't express). The fail-visible design is preserved: a node without its WireGuard annotation goes TargetDown instead of silently scraping cleartext.\n\n**CorednsV6Face** — the v6 DNS face for k0s dual-stack clusters (k0s pins the primary service family to v4; empirically verified). Static SingleStack-IPv6 ClusterIP over the stock CoreDNS pods; pairs with `AwsWorkerFleetOptions.clusterDns`.\n\nHarness-verified: `meshAddress`/`meshMonitorValues` JSON-identical to the consumer literals; CRs synth 1:1 with parameterized names.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)