### PR TITLE
fix(k0s): composed followers exclude LateInitialize

### DIFF
--- a/packages/nebula/src/modules/infra/k0s/worker.ts
+++ b/packages/nebula/src/modules/infra/k0s/worker.ts
@@ -361,6 +361,12 @@ export class WorkerSetup extends Construct {
                     kind: "EIPAssociation",
                     metadata: { name: "placeholder" },
                     spec: {
+                      // No LateInitialize: it captures the observed publicIp
+                      // (association) / device state into spec, and a recreate
+                      // after severance then sends publicIp AND allocationId -
+                      // "may specify public IP or allocation id, but not both"
+                      // (observed live). Same guard the git-era followers had.
+                      managementPolicies: ["Observe", "Create", "Update", "Delete"],
                       forProvider: {
                         region: "placeholder",
                         allowReassociation: true,
@@ -433,6 +439,12 @@ export class WorkerSetup extends Construct {
                     kind: "VolumeAttachment",
                     metadata: { name: "placeholder" },
                     spec: {
+                      // No LateInitialize: it captures the observed publicIp
+                      // (association) / device state into spec, and a recreate
+                      // after severance then sends publicIp AND allocationId -
+                      // "may specify public IP or allocation id, but not both"
+                      // (observed live). Same guard the git-era followers had.
+                      managementPolicies: ["Observe", "Create", "Update", "Delete"],
                       forProvider: {
                         region: "placeholder",
                         deviceName: "placeholder",


### PR DESCRIPTION
The git-era follower MRs carried `managementPolicies` excluding LateInitialize for exactly the failure now observed live: the provider late-initializes the association's `publicIp` into spec, and any recreate after severance (instance replacement / EIP move) sends publicIp AND allocationId → `InvalidParameterCombination`. Guard restored on both composed bases (EIPAssociation, VolumeAttachment). After merge+repin I also strip the already-persisted `publicIp` fields from the 9 live MRs once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)