### PR TITLE
fix(s3): grant object tagging on S3Bucket

### DIFF
--- a/packages/nebula/src/modules/infra/aws/s3.ts
+++ b/packages/nebula/src/modules/infra/aws/s3.ts
@@ -77,6 +77,12 @@ export class S3Bucket extends Construct {
               "s3:PutObject",
               "s3:DeleteObject",
               "s3:AbortMultipartUpload",
+              // Tempo lists object tagging as required; it is also the standard
+              // set Loki/Mimir expect. Omitting it only appears to work where
+              // the node role already carries a broad s3:* from
+              // controllerPolicies, and breaks the moment that is tightened.
+              "s3:GetObjectTagging",
+              "s3:PutObjectTagging",
             ],
             Resource: `${arn}/*`,
           },


### PR DESCRIPTION
Tempo documents `s3:GetObjectTagging` / `s3:PutObjectTagging` as required, and it is the same set Loki and Mimir expect. The `S3Bucket` construct's scoped policy omitted both.

This is masked wherever the consuming node role also carries a broad `s3:*` via `AwsIam` `controllerPolicies` — true for every current consumer, so **nothing is failing today**. It would surface as an opaque S3 error the moment those policies are tightened, or for any consumer relying on the scoped grant alone.

Found while deploying Tempo onto the intra cluster (bucket `nuconstruct-intra-tempo`), where the scoped grant is the documented credential path even though IMDS currently resolves the broader role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)