### PR TITLE
fix(worker-fleet): drop Update from Instance management policies

### DIFF
--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -544,7 +544,13 @@ ${lvmSection}`;
         // No LateInitialize: it captured the first instance's ENI into spec,
         // and after a replacement the provider refuses the resulting "update"
         // forever — wedging reconciliation while the node runs fine.
-        managementPolicies: ["Observe", "Create", "Update", "Delete"],
+        // No Update either: every meaningful Instance change (userData, type,
+        // AMI) requires replacement, which upjet refuses — so Update can only
+        // ever produce the same permanent refusal wedge (observed live:
+        // user_data drift after adoption). Replacement is done by DELETING
+        // the MR/Machine; userDataReplaceOnChange below is inert under this
+        // policy and kept only to document intent for the create path.
+        managementPolicies: ["Observe", "Create", "Delete"],
         forProvider: {
           region: region.region,
           ami: node.ami,


### PR DESCRIPTION
Root cause of the cluster-stage Degraded residue: worker Instance MRs carry the Update policy, but every meaningful Instance change requires replacement, which upjet refuses — a permanent `Synced=False` wedge (observed live on both adopted asia workers via user_data drift). Update could never do anything useful here: the fleet replaces nodes by deleting the MR/Machine.

Aligns the Instance MRs with the module's own established pattern (Eips are already Observe/Create/Delete, LateInitialize was already dropped for the same wedge class).

Context: the asia MRs also leaked 6 duplicate on-demand instances (async-create retries across today's provider restarts, ~$70/day) — terminated; the two live instances are adopted via external-name and go green once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)