### PR TITLE
fix(worker): drop Update from the EIPAssociation follower policy

### DIFF
--- a/packages/nebula/src/modules/infra/k0s/worker.ts
+++ b/packages/nebula/src/modules/infra/k0s/worker.ts
@@ -366,7 +366,12 @@ export class WorkerSetup extends Construct {
                       // after severance then sends publicIp AND allocationId -
                       // "may specify public IP or allocation id, but not both"
                       // (observed live). Same guard the git-era followers had.
-                      managementPolicies: ["Observe", "Create", "Update", "Delete"],
+                      // No Update either: instance_id/allocation_id changes all
+                      // require replacement, which upjet refuses — the follower
+                      // model replaces via the instance-id-derived NAME (new MR,
+                      // GC old), so Update can only ever wedge (observed live:
+                      // 7 followers Synced=False after instance churn).
+                      managementPolicies: ["Observe", "Create", "Delete"],
                       forProvider: {
                         region: "placeholder",
                         allowReassociation: true,


### PR DESCRIPTION
Completes #80's OCD pattern on the composed followers: the instance-id-derived naming already makes replacement create-new + GC-old, so the Update policy can only ever produce upjet's refuse-to-replace wedge — observed live as 7 stage followers stuck Synced=False after instance churn (the composition patched new instance ids into old-named followers' specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)