### PR TITLE
worker-fleet: kill the duplicate-create leak class (Phase 0)

### DIFF
--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -123,11 +123,21 @@ export interface AwsWorkerFleetNode {
   nodeLabels: Record<string, string>;
   /** Raw --register-with-taints entries, e.g. "workload=x:NoSchedule". */
   taints?: string[];
-  /** Data volume size in GiB (the LVM PV under OpenEBS). Omit: no volume. */
-  dataVolumeGi?: number;
-  /** Override the data-volume MR name (an MR rename is a volume REPLACEMENT —
-   *  days of chain resync). Defaults to `<name>-data`. */
-  dataVolumeMrName?: string;
+  /** Data volume (the LVM PV under OpenEBS). FAIL-CLOSED identity: presence
+   *  alone never creates anything — declare the existing volume's id
+   *  (adoption; the id is stable, doctrine-safe in git) or explicitly ask for
+   *  a fresh empty volume. Rules out the silent-recreation failure mode where
+   *  a lost adoption turns days of chain data into a blank disk.
+   *  mrName overrides the MR name (an MR rename is a volume REPLACEMENT —
+   *  days of chain resync); defaults to `<name>-data`. */
+  dataVolume?: { sizeGi: number; mrName?: string } & (
+    | { volumeId: string; createFresh?: never }
+    | { createFresh: true; volumeId?: never }
+  );
+  /** Existing EIP allocation to adopt as this node's Eip MR (external-name).
+   *  Stable id, safe in git — same pattern as dns adoptZoneId. Omit on a
+   *  fresh build: the Eip is allocated and its id then belongs in git. */
+  allocationId?: string;
   rootVolumeGi?: number;
   spot?: boolean;
   /** IMDS hop limit 2: pods on this node may use the node role (keyless AWS
@@ -174,20 +184,29 @@ export class AwsWorkerFleet extends Construct {
 
   /**
    * Allocate a node's stable EIP. Standalone so addresses exist ahead of the
-   * instances. OBSERVE/CREATE/DELETE only: the association is owned by the
-   * Worker composition, and Update/LateInitialize on the Eip itself would
-   * fight it — full management sees the runtime association as drift and
-   * DisassociateAddresses on every reconcile, while LateInitialize captures a
-   * then-current instance id that goes stale on replacement.
+   * instances. No Update: the association is owned by the Worker composition,
+   * and an updating Eip sees the runtime association as drift and
+   * DisassociateAddresses on every reconcile (observed live). LateInitialize
+   * IS on: upjet persists crossplane.io/external-name through the late-init
+   * step after an ASYNC create (crossplane#5918/upjet#531) — without it a
+   * provider restart forgets the allocation and AllocateAddress duplicates
+   * (observed live: 16 stray EIPs). The late-init'd instance field is inert
+   * with Update off. allocationId adopts an existing address (external-name).
    */
-  addEip(name: string, region: string) {
+  addEip(name: string, region: string, allocationId?: string) {
     new Eip(this, `${name}-eip`, {
-      metadata: { name },
+      metadata: {
+        name,
+        ...(allocationId
+          ? { annotations: { "crossplane.io/external-name": allocationId } }
+          : {}),
+      },
       spec: {
         managementPolicies: [
           EipSpecManagementPolicies.OBSERVE,
           EipSpecManagementPolicies.CREATE,
           EipSpecManagementPolicies.DELETE,
+          EipSpecManagementPolicies.LATE_INITIALIZE,
         ],
         forProvider: {
           region,
@@ -442,7 +461,7 @@ export class AwsWorkerFleet extends Construct {
     // Data volume -> LVM VG. create-if-absent ONLY: on instance replacement
     // the volume re-attaches carrying its data — vgcreate on a populated PV
     // would destroy exactly what this design preserves.
-    const lvmSection = node.dataVolumeGi
+    const lvmSection = node.dataVolume
       ? `
 ROOT_PART=$(findmnt -no SOURCE /)
 ROOT_DISK=/dev/$(lsblk -no PKNAME "$ROOT_PART")
@@ -510,20 +529,34 @@ ${lvmSection}`;
   addNode(region: AwsWorkerFleetRegion, node: AwsWorkerFleetNode, iamProfile: string) {
     const o = this.options;
     const p = this.prefix(region);
-    const dataVolumeMrName = node.dataVolumeGi
-      ? (node.dataVolumeMrName ?? `${node.name}-data`)
-      : undefined;
-    if (dataVolumeMrName) {
+    const dv = node.dataVolume;
+    const dataVolumeMrName = dv ? (dv.mrName ?? `${node.name}-data`) : undefined;
+    if (dv && dataVolumeMrName) {
       new ApiObject(this, `${node.name}-data-volume`, {
         apiVersion: "ec2.aws.upbound.io/v1beta1",
         kind: "EBSVolume",
-        metadata: { name: dataVolumeMrName },
+        metadata: {
+          name: dataVolumeMrName,
+          ...(dv.volumeId
+            ? { annotations: { "crossplane.io/external-name": dv.volumeId } }
+            : {}),
+        },
         spec: {
-          deletionPolicy: "Delete",
+          // Data outlives every k8s object: Orphan + no Delete policy means
+          // nothing Crossplane-side can destroy the volume; Create exists
+          // only under an explicit createFresh. Update stays (gp3 size growth
+          // is in-place; the on-node pvresize timer picks it up).
+          deletionPolicy: "Orphan",
+          managementPolicies: [
+            "Observe",
+            ...(dv.createFresh ? ["Create"] : []),
+            "Update",
+            "LateInitialize",
+          ],
           forProvider: {
             region: region.region,
             availabilityZone: region.az,
-            size: node.dataVolumeGi,
+            size: dv.sizeGi,
             type: "gp3",
             encrypted: true,
             tags: {
@@ -541,16 +574,20 @@ ${lvmSection}`;
       metadata: { name: node.name },
       spec: {
         deletionPolicy: "Delete",
-        // No LateInitialize: it captured the first instance's ENI into spec,
-        // and after a replacement the provider refuses the resulting "update"
-        // forever — wedging reconciliation while the node runs fine.
-        // No Update either: every meaningful Instance change (userData, type,
-        // AMI) requires replacement, which upjet refuses — so Update can only
-        // ever produce the same permanent refusal wedge (observed live:
-        // user_data drift after adoption). Replacement is done by DELETING
-        // the MR/Machine; userDataReplaceOnChange below is inert under this
-        // policy and kept only to document intent for the create path.
-        managementPolicies: ["Observe", "Create", "Delete"],
+        // No Update: every meaningful Instance change (userData, type, AMI)
+        // requires replacement, which upjet refuses — so Update can only
+        // ever produce a permanent refusal wedge (observed live: user_data
+        // drift after adoption, and the first instance's ENI late-init'd
+        // into spec). Replacement is done by DELETING the MR/Machine;
+        // userDataReplaceOnChange below is inert under this policy and kept
+        // only to document intent for the create path.
+        // LateInitialize IS required even with Update off: upjet persists
+        // crossplane.io/external-name through the late-init step after an
+        // ASYNC create (crossplane#5918/upjet#531) — without it a provider
+        // restart forgets the create and RunInstances a duplicate (observed
+        // live: 38 leaked instances across three regions). The late-init'd
+        // spec fields are inert because Update stays off.
+        managementPolicies: ["Observe", "Create", "Delete", "LateInitialize"],
         forProvider: {
           region: region.region,
           ami: node.ami,

--- a/packages/nebula/src/modules/infra/k0s/worker.ts
+++ b/packages/nebula/src/modules/infra/k0s/worker.ts
@@ -444,12 +444,12 @@ export class WorkerSetup extends Construct {
                     kind: "VolumeAttachment",
                     metadata: { name: "placeholder" },
                     spec: {
-                      // No LateInitialize: it captures the observed publicIp
-                      // (association) / device state into spec, and a recreate
-                      // after severance then sends publicIp AND allocationId -
-                      // "may specify public IP or allocation id, but not both"
-                      // (observed live). Same guard the git-era followers had.
-                      managementPolicies: ["Observe", "Create", "Update", "Delete"],
+                      // Same policy shape as the eip-association follower:
+                      // every identity field (volume/instance/device) is
+                      // replacement-requiring, replacement happens via the
+                      // instance-id-derived NAME (new MR, GC old), so Update
+                      // and LateInitialize can only pollute spec or wedge.
+                      managementPolicies: ["Observe", "Create", "Delete"],
                       forProvider: {
                         region: "placeholder",
                         deviceName: "placeholder",

--- a/packages/nebula/src/modules/k8s/crossplane-observability/index.ts
+++ b/packages/nebula/src/modules/k8s/crossplane-observability/index.ts
@@ -6,10 +6,10 @@
  * (zombie instances), and MRs sit Synced=False for hours with nothing paging.
  * Observed live during a stage fleet rebuild; the pack has three layers:
  *
- * 1. kube-state-metrics customResourceState turns MR status conditions into
- *    a `crossplane_condition` metric ({@link kubeStateMetricsValues} — a
- *    values fragment for the kube-prometheus-stack chart, since ksm config is
- *    chart-side, not a CR).
+ * 1. kube-state-metrics customResourceState turns MR status conditions AND
+ *    the create/identity annotations into metrics ({@link
+ *    kubeStateMetricsValues} — a values fragment for the kube-prometheus-stack
+ *    chart, since ksm config is chart-side, not a CR).
  * 2. Two PodMonitors scrape the controllers — core crossplane serves metrics
  *    on 8080 (8081 is readyz and 404s /metrics), providers (labeled
  *    pkg.crossplane.io/provider) also on 8080. Providers only, NOT the
@@ -17,8 +17,9 @@
  *    label too but serve gRPC with no metrics endpoint — matching them
  *    leaves permanently-down targets (observed: TargetDown crossplane-system
  *    for all three function pods).
- * 3. A PrometheusRule alerting on Synced=False, on provider silence, and on
- *    the scrape itself going blind.
+ * 3. A PrometheusRule alerting on Synced=False, on the duplicate-create
+ *    precursors (Ready without external-name; stuck external-create-pending),
+ *    on provider silence, and on the scrape itself going blind.
  *
  * The silence rule's rate window must OUTLAST the providers' resync interval:
  * a zero-MR provider's only activity is an hourly resync burst (observed:
@@ -107,6 +108,41 @@ export function kubeStateMetricsValues(kinds: CrossplaneWatchedKind[]): object {
                     },
                   },
                 },
+                // External identity: an MR that is Ready without an
+                // external-name loses its external on the next provider
+                // restart and re-creates a duplicate (the leak class).
+                {
+                  name: "crossplane_external_name",
+                  help: "crossplane.io/external-name annotation (external_name label; absent/empty when unset)",
+                  each: {
+                    type: "Info",
+                    info: {
+                      path: ["metadata", "annotations"],
+                      labelsFromPath: {
+                        external_name: ["crossplane.io/external-name"],
+                      },
+                    },
+                  },
+                },
+                // The async-create audit trail as epoch gauges (ksm parses
+                // RFC3339 into seconds; nilIsZero → comparable 0 when absent):
+                // pending newer than both outcomes = crossplane refuses to
+                // reconcile until an operator resolves the create.
+                ...["pending", "succeeded", "failed"].map((phase) => ({
+                  name: `crossplane_external_create_${phase}`,
+                  help: `crossplane.io/external-create-${phase} annotation as epoch seconds (0 when absent)`,
+                  each: {
+                    type: "Gauge",
+                    gauge: {
+                      path: [
+                        "metadata",
+                        "annotations",
+                        `crossplane.io/external-create-${phase}`,
+                      ],
+                      nilIsZero: true,
+                    },
+                  },
+                })),
               ],
             })),
           },
@@ -175,6 +211,36 @@ export class CrossplaneObservability extends Construct {
                   summary: "MR {{ $labels.name }} Synced=False for 30m",
                   description:
                     "A Crossplane managed resource has failed to reconcile for 30 minutes - wedged update/delete or provider error. Inspect: kubectl describe {{ $labels.customresource_kind }} {{ $labels.name }}",
+                },
+              },
+              {
+                // The duplicate-create precursor (observed live: 38 leaked
+                // instances + 16 stray EIPs): a Ready MR without an
+                // external-name is one provider restart away from forgetting
+                // its external and creating a clone. Empty-label matcher
+                // covers both ksm behaviors for a missing annotation (series
+                // skipped vs emitted label-less).
+                alert: "CrossplaneExternalNameMissing",
+                expr: 'kube_customresource_crossplane_condition{type="Ready"} == 1 unless on (cluster, customresource_kind, name) kube_customresource_crossplane_external_name{external_name!=""}',
+                for: "15m",
+                labels: { severity: "critical" },
+                annotations: {
+                  summary:
+                    "MR {{ $labels.name }} is Ready without an external-name",
+                  description:
+                    "A Ready managed resource carries no crossplane.io/external-name: the next provider restart loses the external identity and CREATES A DUPLICATE (the instance-leak class). Re-adopt now: kubectl annotate {{ $labels.customresource_kind }} {{ $labels.name }} crossplane.io/external-name=<live id>.",
+                },
+              },
+              {
+                alert: "CrossplaneExternalCreateStuck",
+                expr: "(kube_customresource_crossplane_external_create_pending > on (cluster, customresource_kind, name) kube_customresource_crossplane_external_create_succeeded) and on (cluster, customresource_kind, name) (kube_customresource_crossplane_external_create_pending > on (cluster, customresource_kind, name) kube_customresource_crossplane_external_create_failed)",
+                for: "20m",
+                labels: { severity: "warning" },
+                annotations: {
+                  summary:
+                    "MR {{ $labels.name }} stuck in external-create-pending",
+                  description:
+                    "external-create-pending is newer than both -succeeded and -failed: the provider died mid-create and crossplane refuses to reconcile this MR until an operator verifies the external state and removes the crossplane.io/external-create-pending annotation.",
                 },
               },
               {


### PR DESCRIPTION
Phase 0 of the zero-manual-steps program.

**Root cause** (crossplane#5918 / upjet#531): with `LateInitialize` dropped from `managementPolicies`, upjet cannot persist `crossplane.io/external-name` after an **async** create — a provider restart then forgets the create ever happened and duplicates it (observed live: 38 leaked instances + 16 stray EIPs, waves matching each provider restart). `Update` stays off everywhere it could wedge; late-init'd spec is inert without it.

- **Instance + Eip MRs**: policies gain `LateInitialize` — external-name survives async create + provider churn.
- **Eip**: optional `allocationId` adopts an existing address via external-name (stable id, doctrine-safe in git; the `adoptZoneId` pattern).
- **Data EBSVolume, fail-closed**: `deletionPolicy: Orphan`, no `Delete` policy, `Create` only under explicit `createFresh`. Node config takes a type-enforced union `dataVolume: {volumeId} | {createFresh: true}` — a lost adoption can never silently replace chain data with a blank disk.
- **VolumeAttachment follower**: drop `Update` (identity fields are replacement-requiring; replacement rides the instance-id-derived name). Followers keep `LateInitialize` OFF — it pollutes the create path of a name-recreated follower (observed live: "may specify public IP or allocation id, but not both").
- **CrossplaneObservability**: ksm exports `external-name` + `external-create-*` annotations; two new alerts — `CrossplaneExternalNameMissing` (critical, the leak precursor) and `CrossplaneExternalCreateStuck` (warning).

Follow-up (DevOps repin): stage allocationIds + volumeIds land in config; canary on asia first; verify = double provider bounce → zero new instances in 3 regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)