### PR TITLE
crossplane-observability: exclude association kinds from external-name alert

### DIFF
--- a/packages/nebula/src/modules/k8s/crossplane-observability/index.ts
+++ b/packages/nebula/src/modules/k8s/crossplane-observability/index.ts
@@ -219,9 +219,14 @@ export class CrossplaneObservability extends Construct {
                 // external-name is one provider restart away from forgetting
                 // its external and creating a clone. Empty-label matcher
                 // covers both ksm behaviors for a missing annotation (series
-                // skipped vs emitted label-less).
+                // skipped vs emitted label-less). Association/attachment
+                // kinds are excluded: their Create binds EXISTING identities
+                // (re-create converges, nothing duplicates), and follower MRs
+                // deliberately run without LateInitialize, so async creates
+                // legitimately leave them annotation-less (observed live on
+                // spot-remediated EIPAssociation followers).
                 alert: "CrossplaneExternalNameMissing",
-                expr: 'kube_customresource_crossplane_condition{type="Ready"} == 1 unless on (cluster, customresource_kind, name) kube_customresource_crossplane_external_name{external_name!=""}',
+                expr: 'kube_customresource_crossplane_condition{type="Ready", customresource_kind!~".*Association|.*Attachment"} == 1 unless on (cluster, customresource_kind, name) kube_customresource_crossplane_external_name{external_name!=""}',
                 for: "15m",
                 labels: { severity: "critical" },
                 annotations: {


### PR DESCRIPTION
Follow-up to #82: `CrossplaneExternalNameMissing` now excludes `.*Association|.*Attachment` kinds — their Create binds existing identities (re-create converges, no duplicate), and the Worker XR followers deliberately run without LateInitialize, so they legitimately lack the annotation after async creates. Observed live: 2 spot-remediated EIPAssociation followers went pending-critical minutes after the rule landed (their ids backfilled from atProvider meanwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)