### PR TITLE
Name the managementPolicies instead of hand-writing them

### DIFF
--- a/packages/nebula/package.json
+++ b/packages/nebula/package.json
@@ -27,6 +27,7 @@
     "synth": "cdk8s synth",
     "import": "cdk8s import",
     "generate-claims": "tsx scripts/generate-claim-types.ts",
+    "verify:policies": "tsx scripts/verify-policies.ts",
     "example:synth": "cdk8s synth --app 'tsx example/main.ts'",
     "example:aws:synth": "cdk8s synth --app 'tsx example/aws.ts'",
     "example:vendor-free:synth": "cdk8s synth --app 'tsx example/vendor-free.ts'"

--- a/packages/nebula/scripts/verify-policies.ts
+++ b/packages/nebula/scripts/verify-policies.ts
@@ -1,0 +1,57 @@
+/**
+ * Fail the build if any managementPolicies is hand-authored as an array.
+ *
+ * The duplicate-create leak class came from an array literal that looked
+ * correct at the call site (see src/utils/crossplane-policies.ts). Named
+ * constants fix the sites we have; this keeps the next one honest, since
+ * TypeScript cannot help — the leak-prone MRs are built as untyped ApiObject
+ * specs, so there is no type to constrain.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+const ALLOWLIST = ["utils/crossplane-policies.ts"];
+
+/** Blank out comments so prose mentioning the field is not a false positive.
+ *  Blanking rather than deleting keeps byte offsets, so reported line numbers
+ *  still point at the real source. */
+const decomment = (s: string) =>
+  s.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, (m) => m.replace(/[^\n]/g, " "));
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    return statSync(full).isDirectory()
+      ? walk(full)
+      : full.endsWith(".ts")
+        ? [full]
+        : [];
+  });
+
+const violations: string[] = [];
+for (const file of walk(SRC)) {
+  const rel = relative(SRC, file);
+  if (ALLOWLIST.includes(rel)) continue;
+  const source = decomment(readFileSync(file, "utf8"));
+  // \s spans newlines, so `managementPolicies:\n  [` is caught too.
+  for (const match of source.matchAll(/managementPolicies\s*:\s*\[/g)) {
+    const line = source.slice(0, match.index).split("\n").length;
+    violations.push(`${rel}:${line}`);
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    "managementPolicies must use a named constant from " +
+      "src/utils/crossplane-policies.ts, not an array literal.\n" +
+      "OWNED_POLICIES (we create the external) / FOLLOWER_POLICIES (binds an\n" +
+      "existing identity) / OBSERVE_POLICIES / dataVolumePolicies().\n\n" +
+      "Array literals here:\n" +
+      violations.map((v) => `  ${v}`).join("\n"),
+  );
+  process.exit(1);
+}
+
+console.log(`ok — no hand-authored managementPolicies (${SRC})`);

--- a/packages/nebula/src/modules/infra/aws/dualstack-subnet.ts
+++ b/packages/nebula/src/modules/infra/aws/dualstack-subnet.ts
@@ -22,6 +22,7 @@ import {
   CompositionSpecMode,
 } from "#imports/apiextensions.crossplane.io";
 import { ARGOCD_SYNC_WAVE_ANNOTATION } from "../../../core";
+import { OBSERVE_POLICIES } from "../../../utils/crossplane-policies";
 
 export interface DualStackSubnetConfig {
   /** metadata.name of the Vpc managed resource to observe. */
@@ -124,7 +125,7 @@ export class DualStackSubnetSetup extends Construct {
                     apiVersion: "kubernetes.crossplane.io/v1alpha2",
                     kind: "Object",
                     spec: {
-                      managementPolicies: ["Observe"],
+                      managementPolicies: OBSERVE_POLICIES,
                       forProvider: {
                         manifest: {
                           apiVersion: "ec2.aws.upbound.io/v1beta1",

--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -29,6 +29,11 @@ import { Worker } from "../k0s/worker";
 import { DualStackSubnet } from "./dualstack-subnet";
 import { resolveSecrets } from "../../../utils/secrets";
 import {
+  OWNED_POLICIES,
+  asPolicies,
+  dataVolumePolicies,
+} from "../../../utils/crossplane-policies";
+import {
   Eip,
   EipSpecManagementPolicies,
   InternetGateway,
@@ -184,14 +189,12 @@ export class AwsWorkerFleet extends Construct {
 
   /**
    * Allocate a node's stable EIP. Standalone so addresses exist ahead of the
-   * instances. No Update: the association is owned by the Worker composition,
-   * and an updating Eip sees the runtime association as drift and
-   * DisassociateAddresses on every reconcile (observed live). LateInitialize
-   * IS on: upjet persists crossplane.io/external-name through the late-init
-   * step after an ASYNC create (crossplane#5918/upjet#531) — without it a
-   * provider restart forgets the allocation and AllocateAddress duplicates
-   * (observed live: 16 stray EIPs). The late-init'd instance field is inert
-   * with Update off. allocationId adopts an existing address (external-name).
+   * instances. OWNED_POLICIES also buys the EIP-specific guard that Update
+   * must stay off here: the association is owned by the Worker composition,
+   * so an updating Eip sees the runtime association as drift and
+   * DisassociateAddresses on every reconcile (observed live) — and dropping
+   * LateInitialize instead cost 16 stray EIPs. allocationId adopts an
+   * existing address (external-name).
    */
   addEip(name: string, region: string, allocationId?: string) {
     new Eip(this, `${name}-eip`, {
@@ -202,12 +205,8 @@ export class AwsWorkerFleet extends Construct {
           : {}),
       },
       spec: {
-        managementPolicies: [
-          EipSpecManagementPolicies.OBSERVE,
-          EipSpecManagementPolicies.CREATE,
-          EipSpecManagementPolicies.DELETE,
-          EipSpecManagementPolicies.LATE_INITIALIZE,
-        ],
+        managementPolicies:
+          asPolicies<EipSpecManagementPolicies>(OWNED_POLICIES),
         forProvider: {
           region,
           domain: "vpc",
@@ -542,17 +541,11 @@ ${lvmSection}`;
             : {}),
         },
         spec: {
-          // Data outlives every k8s object: Orphan + no Delete policy means
-          // nothing Crossplane-side can destroy the volume; Create exists
-          // only under an explicit createFresh. Update stays (gp3 size growth
-          // is in-place; the on-node pvresize timer picks it up).
+          // Orphan pairs with dataVolumePolicies' missing Delete: nothing
+          // Crossplane-side can destroy the volume. The on-node pvresize
+          // timer picks up the in-place gp3 growth Update allows.
           deletionPolicy: "Orphan",
-          managementPolicies: [
-            "Observe",
-            ...(dv.createFresh ? ["Create"] : []),
-            "Update",
-            "LateInitialize",
-          ],
+          managementPolicies: dataVolumePolicies(dv.createFresh),
           forProvider: {
             region: region.region,
             availabilityZone: region.az,
@@ -574,20 +567,10 @@ ${lvmSection}`;
       metadata: { name: node.name },
       spec: {
         deletionPolicy: "Delete",
-        // No Update: every meaningful Instance change (userData, type, AMI)
-        // requires replacement, which upjet refuses — so Update can only
-        // ever produce a permanent refusal wedge (observed live: user_data
-        // drift after adoption, and the first instance's ENI late-init'd
-        // into spec). Replacement is done by DELETING the MR/Machine;
-        // userDataReplaceOnChange below is inert under this policy and kept
-        // only to document intent for the create path.
-        // LateInitialize IS required even with Update off: upjet persists
-        // crossplane.io/external-name through the late-init step after an
-        // ASYNC create (crossplane#5918/upjet#531) — without it a provider
-        // restart forgets the create and RunInstances a duplicate (observed
-        // live: 38 leaked instances across three regions). The late-init'd
-        // spec fields are inert because Update stays off.
-        managementPolicies: ["Observe", "Create", "Delete", "LateInitialize"],
+        // Replacement is done by DELETING the MR/Machine, since OWNED_POLICIES
+        // keeps Update off; userDataReplaceOnChange below is inert under that
+        // policy and kept only to document intent for the create path.
+        managementPolicies: OWNED_POLICIES,
         forProvider: {
           region: region.region,
           ami: node.ami,

--- a/packages/nebula/src/modules/infra/dns/eip-record.ts
+++ b/packages/nebula/src/modules/infra/dns/eip-record.ts
@@ -24,6 +24,7 @@ import {
   CompositionSpecMode,
 } from "#imports/apiextensions.crossplane.io";
 import { ARGOCD_SYNC_WAVE_ANNOTATION } from "../../../core";
+import { OBSERVE_POLICIES } from "../../../utils/crossplane-policies";
 
 export interface EipDnsRecordConfig {
   /** metadata.name of the Eip managed resource to observe (cluster-scoped). */
@@ -178,7 +179,7 @@ spec:
                     apiVersion: "kubernetes.crossplane.io/v1alpha2",
                     kind: "Object",
                     spec: {
-                      managementPolicies: ["Observe"],
+                      managementPolicies: OBSERVE_POLICIES,
                       forProvider: {
                         manifest: {
                           apiVersion: "ec2.aws.upbound.io/v1beta1",

--- a/packages/nebula/src/modules/infra/k0s/worker.ts
+++ b/packages/nebula/src/modules/infra/k0s/worker.ts
@@ -48,6 +48,10 @@ import {
   CompositionSpecMode,
 } from "#imports/apiextensions.crossplane.io";
 import { ARGOCD_SYNC_WAVE_ANNOTATION } from "../../../core";
+import {
+  FOLLOWER_POLICIES,
+  OBSERVE_POLICIES,
+} from "../../../utils/crossplane-policies";
 
 export interface WorkerConfig {
   /** metadata.name of the Eip managed resource to observe (cluster-scoped). */
@@ -81,7 +85,7 @@ const observeBase = (kind: string) => ({
   apiVersion: "kubernetes.crossplane.io/v1alpha2",
   kind: "Object",
   spec: {
-    managementPolicies: ["Observe"],
+    managementPolicies: OBSERVE_POLICIES,
     forProvider: {
       manifest: {
         apiVersion: "ec2.aws.upbound.io/v1beta1",
@@ -361,17 +365,7 @@ export class WorkerSetup extends Construct {
                     kind: "EIPAssociation",
                     metadata: { name: "placeholder" },
                     spec: {
-                      // No LateInitialize: it captures the observed publicIp
-                      // (association) / device state into spec, and a recreate
-                      // after severance then sends publicIp AND allocationId -
-                      // "may specify public IP or allocation id, but not both"
-                      // (observed live). Same guard the git-era followers had.
-                      // No Update either: instance_id/allocation_id changes all
-                      // require replacement, which upjet refuses — the follower
-                      // model replaces via the instance-id-derived NAME (new MR,
-                      // GC old), so Update can only ever wedge (observed live:
-                      // 7 followers Synced=False after instance churn).
-                      managementPolicies: ["Observe", "Create", "Delete"],
+                      managementPolicies: FOLLOWER_POLICIES,
                       forProvider: {
                         region: "placeholder",
                         allowReassociation: true,
@@ -444,12 +438,7 @@ export class WorkerSetup extends Construct {
                     kind: "VolumeAttachment",
                     metadata: { name: "placeholder" },
                     spec: {
-                      // Same policy shape as the eip-association follower:
-                      // every identity field (volume/instance/device) is
-                      // replacement-requiring, replacement happens via the
-                      // instance-id-derived NAME (new MR, GC old), so Update
-                      // and LateInitialize can only pollute spec or wedge.
-                      managementPolicies: ["Observe", "Create", "Delete"],
+                      managementPolicies: FOLLOWER_POLICIES,
                       forProvider: {
                         region: "placeholder",
                         deviceName: "placeholder",

--- a/packages/nebula/src/modules/k8s/argocd/argocd-cluster-sync.ts
+++ b/packages/nebula/src/modules/k8s/argocd/argocd-cluster-sync.ts
@@ -36,6 +36,7 @@ import {
   CompositionSpecMode,
 } from "#imports/apiextensions.crossplane.io";
 import { ARGOCD_SYNC_WAVE_ANNOTATION } from "../../../core";
+import { OBSERVE_POLICIES } from "../../../utils/crossplane-policies";
 
 export interface ArgoCdClusterSyncConfig {
   /** Human-readable cluster name (used in ArgoCD UI) */
@@ -231,7 +232,7 @@ stringData:
                     apiVersion: "kubernetes.crossplane.io/v1alpha2",
                     kind: "Object",
                     spec: {
-                      managementPolicies: ["Observe"],
+                      managementPolicies: OBSERVE_POLICIES,
                       forProvider: {
                         manifest: {
                           apiVersion: "v1",

--- a/packages/nebula/src/modules/k8s/karmada/credential-sync.ts
+++ b/packages/nebula/src/modules/k8s/karmada/credential-sync.ts
@@ -45,6 +45,7 @@ import {
   CompositionSpecMode,
 } from "#imports/apiextensions.crossplane.io";
 import { ARGOCD_SYNC_WAVE_ANNOTATION } from "../../../core";
+import { OBSERVE_POLICIES } from "../../../utils/crossplane-policies";
 
 export interface KarmadaCredentialSyncConfig {
   /** Human-readable cluster name */
@@ -222,7 +223,7 @@ spec:
                     apiVersion: "kubernetes.crossplane.io/v1alpha2",
                     kind: "Object",
                     spec: {
-                      managementPolicies: ["Observe"],
+                      managementPolicies: OBSERVE_POLICIES,
                       forProvider: {
                         manifest: {
                           apiVersion: "v1",

--- a/packages/nebula/src/utils/crossplane-policies.ts
+++ b/packages/nebula/src/utils/crossplane-policies.ts
@@ -1,0 +1,85 @@
+/**
+ * Crossplane managementPolicies, named by what the resource IS.
+ *
+ * Hand-authoring these arrays is how the duplicate-create leak class got in.
+ * worker-fleet.ts was born with ["Observe","Create","Update","Delete"] to stop
+ * late-init capturing the first instance's ENI into spec — a real wedge — but
+ * that also, invisibly, disabled external-name persistence. Nothing about the
+ * array looked wrong at the call site, and the rationale lived in a comment
+ * that did not travel to the next MR someone added.
+ *
+ * So: pick the name that describes the resource, and the policy follows. The
+ * choice between these is semantic and deliberate; an array literal is not.
+ */
+
+/**
+ * An external we create and own outright (Instance, Eip).
+ *
+ * LateInitialize is NON-NEGOTIABLE. Upjet persists crossplane.io/external-name
+ * through the late-init step after an ASYNC create (crossplane#5918 /
+ * upjet#531); without it a provider restart forgets the create and makes a
+ * duplicate — observed live twice, 38 leaked instances across three regions
+ * and 7 more on 2026-08-01.
+ *
+ * Update is off. Every meaningful change (userData, type, AMI) is
+ * replacement-requiring, which upjet refuses, so Update can only ever produce
+ * a permanent refusal wedge. Note it is Update — not LateInitialize — that
+ * turns late-init's spec writes into rejected updates; with Update off the
+ * late-init'd fields are inert. Replacement is done by DELETING the MR.
+ */
+export const OWNED_POLICIES: readonly string[] = [
+  "Observe",
+  "Create",
+  "Delete",
+  "LateInitialize",
+];
+
+/**
+ * A follower that BINDS identities something else owns (EIPAssociation,
+ * VolumeAttachment).
+ *
+ * LateInitialize is deliberately absent here: it captures the observed
+ * publicIp (association) / device state into spec, and a recreate after
+ * severance then sends publicIp AND allocationId — "may specify public IP or
+ * allocation id, but not both" (observed live). Nothing leaks by omitting it,
+ * because Create binds an EXISTING identity, so a re-create converges.
+ *
+ * Update is off for the same reason as OWNED_POLICIES: every identity field
+ * (instance/allocation/volume/device) is replacement-requiring, and
+ * replacement happens via the instance-id-derived NAME (new MR, GC old), so
+ * Update can only wedge (observed live: 7 followers Synced=False after churn).
+ */
+export const FOLLOWER_POLICIES: readonly string[] = [
+  "Observe",
+  "Create",
+  "Delete",
+];
+
+/** Read-only observation — no Create, so there is no external identity to
+ *  persist and no leak class to guard against. */
+export const OBSERVE_POLICIES: readonly string[] = ["Observe"];
+
+/**
+ * Data that outlives every k8s object (EBSVolume).
+ *
+ * No Delete — paired with deletionPolicy Orphan, nothing Crossplane-side can
+ * destroy the volume. Create exists only under an explicit createFresh, so a
+ * missing volumeId fails closed instead of silently provisioning an empty
+ * disk. Update stays because gp3 size growth is in-place.
+ */
+export const dataVolumePolicies = (createFresh = false): string[] => [
+  "Observe",
+  ...(createFresh ? ["Create"] : []),
+  "Update",
+  "LateInitialize",
+];
+
+/**
+ * Narrow the canonical strings to a kind's generated enum.
+ *
+ * Every `*SpecManagementPolicies` enum cdk8s generates declares identical
+ * string values, but they are distinct nominal types. Typed constructs (Eip)
+ * want the enum; ApiObject and Composition bases take plain strings.
+ */
+export const asPolicies = <T extends string>(policies: readonly string[]): T[] =>
+  policies as T[];

--- a/packages/nebula/src/utils/index.ts
+++ b/packages/nebula/src/utils/index.ts
@@ -3,3 +3,10 @@
  */
 
 export { resolveSecrets, hasUnresolvedSecrets, setSecretResolutionMode } from './secrets';
+export {
+  OWNED_POLICIES,
+  FOLLOWER_POLICIES,
+  OBSERVE_POLICIES,
+  dataVolumePolicies,
+  asPolicies,
+} from './crossplane-policies';


### PR DESCRIPTION
## Why

The duplicate-create leak class entered through an array literal that looked correct where it was written.

`worker-fleet.ts` was *born* without `LateInitialize` — deliberately, in 6c43724:

```ts
// No LateInitialize: it captured the first instance's ENI into spec,
// and after a replacement the provider refuses the resulting "update"
// forever — wedging reconciliation while the node runs fine.
managementPolicies: ["Observe", "Create", "Update", "Delete"],
```

That was a real wedge, but the attribution was wrong. `Update` — not `LateInitialize` — is what turns late-init's spec writes into rejected updates. And upjet only persists `crossplane.io/external-name` through the late-init step after an async create (crossplane#5918, upjet#531), so dropping it silently disabled identity persistence. Two leaks followed: 38 instances, then 7 more on 2026-08-01.

The costly part is the middle of the history:

| commit | policy | effect |
|---|---|---|
| `6c43724` | `[Observe, Create, Update, Delete]` | late-init out to stop the ENI wedge; **Update in** — the actual culprit |
| `ef27a41` | `[Observe, Create, Delete]` | Update dropped: the hazard is gone, but late-init stays out |
| `d4b8354` | `[Observe, Create, Delete, LateInitialize]` | both correct at once |

After `ef27a41`, `LateInitialize` was already safe to restore — but the rationale lived in a comment at one call site and never travelled, so nothing prompted revisiting it. The leak class stayed live on a rationale that had already expired.

## What

Ten sites now use constants named for what the resource **is**, each carrying its rationale once:

- `OWNED_POLICIES` — we create the external (Instance, Eip). LateInitialize non-negotiable.
- `FOLLOWER_POLICIES` — binds an identity something else owns (EIPAssociation, VolumeAttachment). LateInitialize deliberately absent; nothing leaks because Create binds an *existing* identity.
- `OBSERVE_POLICIES` — read-only.
- `dataVolumePolicies(createFresh)` — no Delete, fail-closed Create.

Choosing between these is a semantic decision someone has to make on purpose. An array literal is not — and the specific mistake in `ef27a41` (dropping `Update` and losing a neighbouring element) becomes a boolean, not a rewrite.

## Enforcement

TypeScript can't help here: the leak-prone MRs (`Instance`, `EBSVolume`) are built as untyped `ApiObject` specs, and each kind's typed construct declares its own nominal enum. So `pnpm verify:policies` fails the build on any hand-authored array. Negative-tested — it exits 1 and reports the correct file:line.

## Validation

No behavioural change. Synthesized output is byte-identical to `main` across 14 rendered `managementPolicies` blocks — the AWS example, plus a throwaway app exercising `AwsWorkerFleet.addEip`/`addNode` and `WorkerSetup` so all four shapes actually render (the committed AWS example uses CAPA and never builds a worker fleet). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)