### PR TITLE
Scheduled EBS snapshots via Data Lifecycle Manager

### DIFF
--- a/packages/nebula/src/modules/infra/aws/dlm.ts
+++ b/packages/nebula/src/modules/infra/aws/dlm.ts
@@ -1,0 +1,170 @@
+/**
+ * Scheduled EBS snapshots via Data Lifecycle Manager.
+ *
+ * The estate ran with NO backups of any kind — a 2026-08-02 sweep found zero
+ * snapshots in every region. Chain data volumes are the exposure that matters:
+ * a lost 768Gi volume is days of resync, and until now nothing but the single
+ * AZ-local copy stood behind it.
+ *
+ * DLM rather than AWS Backup: this is EBS-only, tag-targeted, needs no vault,
+ * and the schedule is the whole feature. AWS Backup earns its extra surface
+ * (vaults, restore testing, cross-account) only once there is something other
+ * than EBS to protect.
+ *
+ * Snapshots are crash-consistent, not application-consistent — DLM does not
+ * quiesce the filesystem. That is the right trade for chain data (the client
+ * replays its WAL on start) and is NOT a substitute for an etcd backup, which
+ * needs `k0s etcd backup` semantics rather than a block-level copy.
+ */
+import { Construct } from "constructs";
+import {
+  Role as CpRole,
+  RolePolicyAttachment as CpRolePolicyAttachment,
+} from "#imports/iam.aws.upbound.io";
+import { LifecyclePolicyV1Beta2 } from "#imports/dlm.aws.upbound.io";
+
+/** DLM assumes this role to create and delete snapshots on your behalf. */
+const DLM_ASSUME_ROLE_POLICY = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "dlm.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+});
+
+const DLM_SERVICE_POLICY_ARN =
+  "arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole";
+
+/** DLM accepts only these create intervals (hours). */
+const VALID_INTERVALS = [1, 2, 3, 4, 6, 8, 12, 24];
+
+export interface DlmSnapshotSchedule {
+  /** Policy name — also the DLM description, which AWS requires. */
+  name: string;
+  region: string;
+  /**
+   * Volumes carrying ALL of these tags are snapshotted. DLM matches key AND
+   * value exactly, so a per-node tag (e.g. `<domain>/node: stage-eu-tool-1`)
+   * cannot be a target — use a constant marker tag.
+   */
+  targetTags: Record<string, string>;
+  /** Hours between snapshots — one of 1,2,3,4,6,8,12,24 (default 24). */
+  intervalHours?: number;
+  /** UTC start times, "HH:MM" (default ["03:00"] — off-peak for EU/NA/ASIA). */
+  times?: string[];
+  /** How many snapshots to keep (default 7). */
+  retain?: number;
+  /**
+   * Copy the volume's tags onto the snapshot (default true). Without this a
+   * restore cannot tell which node a snapshot came from — the tags are the
+   * only identity a snapshot carries.
+   */
+  copyTags?: boolean;
+}
+
+export interface AwsDlmConfig {
+  /** Resource-name prefix, e.g. "stage". */
+  name: string;
+  schedules: DlmSnapshotSchedule[];
+  /** Crossplane ProviderConfig (default "default"). */
+  providerConfigRef?: string;
+  tags?: Record<string, string>;
+}
+
+/**
+ * One shared DLM execution role plus a LifecyclePolicy per schedule.
+ *
+ * The role is shared because DLM's permissions are identical for every policy
+ * (create/delete snapshot, describe volumes) and AWS's own default role is a
+ * singleton per account — a role per schedule would be noise with no isolation
+ * benefit.
+ */
+export class AwsDlm extends Construct {
+  /** AWS name of the DLM execution role. */
+  public readonly roleName: string;
+
+  constructor(scope: Construct, id: string, config: AwsDlmConfig) {
+    super(scope, id);
+
+    const providerConfigRef = { name: config.providerConfigRef ?? "default" };
+    this.roleName = `${config.name}-dlm-role`;
+    const tags = { ...config.tags, "nebula.sh/role": "dlm" };
+
+    // Deterministic AWS name via external-name, matching AwsIam: the policies
+    // below reference the role by name, so a generated name would not resolve.
+    new CpRole(this, "dlm-role", {
+      metadata: {
+        name: this.roleName,
+        annotations: { "crossplane.io/external-name": this.roleName },
+      },
+      spec: {
+        forProvider: {
+          assumeRolePolicy: DLM_ASSUME_ROLE_POLICY,
+          description: "Nebula EBS snapshot lifecycle (DLM) execution role",
+          tags,
+        },
+        providerConfigRef,
+      },
+    });
+
+    new CpRolePolicyAttachment(this, "dlm-role-policy", {
+      metadata: { name: `${config.name}-dlm-policy` },
+      spec: {
+        forProvider: {
+          policyArn: DLM_SERVICE_POLICY_ARN,
+          roleRef: { name: this.roleName },
+        },
+        providerConfigRef,
+      },
+    });
+
+    for (const s of config.schedules) {
+      const interval = s.intervalHours ?? 24;
+      if (!VALID_INTERVALS.includes(interval)) {
+        throw new Error(
+          `DLM schedule "${s.name}": intervalHours must be one of ` +
+            `${VALID_INTERVALS.join(", ")} (got ${interval})`,
+        );
+      }
+      if (Object.keys(s.targetTags).length === 0) {
+        // An empty target set matches every volume in the region, which is a
+        // silent way to snapshot the entire estate on a schedule.
+        throw new Error(`DLM schedule "${s.name}": targetTags must not be empty`);
+      }
+
+      new LifecyclePolicyV1Beta2(this, `dlm-${s.name}`, {
+        metadata: { name: `${config.name}-${s.name}` },
+        spec: {
+          forProvider: {
+            region: s.region,
+            description: `${config.name}-${s.name}`,
+            executionRoleArnRef: { name: this.roleName },
+            state: "ENABLED",
+            tags,
+            policyDetails: {
+              policyType: "EBS_SNAPSHOT_MANAGEMENT",
+              resourceTypes: ["VOLUME"],
+              targetTags: s.targetTags,
+              schedule: [
+                {
+                  name: s.name,
+                  copyTags: s.copyTags ?? true,
+                  createRule: {
+                    interval,
+                    intervalUnit: "HOURS",
+                    times: s.times ?? ["03:00"],
+                  },
+                  retainRule: { count: s.retain ?? 7 },
+                },
+              ],
+            },
+          },
+          providerConfigRef,
+        },
+      });
+    }
+  }
+}

--- a/packages/nebula/src/modules/infra/aws/index.ts
+++ b/packages/nebula/src/modules/infra/aws/index.ts
@@ -10,6 +10,8 @@ export type { NodeIngressRuleSpec, SpotSelection } from "./_shared";
 export type { AwsIamConfig } from "./iam";
 export { S3Bucket } from "./s3";
 export type { S3BucketConfig } from "./s3";
+export { AwsDlm } from "./dlm";
+export type { AwsDlmConfig, DlmSnapshotSchedule } from "./dlm";
 export { AwsK0sCluster } from "./k0s-cluster";
 // Re-export so consumers can set controlPlaneLoadBalancerScheme without a deep import.
 export { AwsClusterV1Beta2SpecControlPlaneLoadBalancerScheme } from "#imports/infrastructure.cluster.x-k8s.io";

--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -130,7 +130,13 @@ export interface AwsWorkerFleetNode {
    *  a lost adoption turns days of chain data into a blank disk.
    *  mrName overrides the MR name (an MR rename is a volume REPLACEMENT —
    *  days of chain resync); defaults to `<name>-data`. */
-  dataVolume?: { sizeGi: number; mrName?: string } & (
+  dataVolume?: {
+    sizeGi: number;
+    mrName?: string;
+    /** Tag the volume for the DLM daily snapshot policy (default true — a
+     *  data volume exists because losing it costs days of resync). */
+    snapshot?: boolean;
+  } & (
     | { volumeId: string; createFresh?: never }
     | { createFresh: true; volumeId?: never }
   );
@@ -562,6 +568,11 @@ ${lvmSection}`;
             tags: {
               Name: `${node.name}-data`,
               [`${o.tagDomain}/node`]: node.name,
+              // Constant value on purpose: DLM targetTags match key AND value
+              // exactly, so the per-node tag above can never be a target.
+              ...(dv.snapshot === false
+                ? {}
+                : { [`${o.tagDomain}/backup`]: "daily" }),
             },
           },
           providerConfigRef: this.pcRef,


### PR DESCRIPTION
## Why

A sweep of the estate on 2026-08-02 found **zero snapshots in every region** — no DLM policy, no AWS Backup plan, nothing. Every data volume was a single AZ-local copy. A lost 768Gi chain volume is days of resync.

(The four snapshots that did exist were stale Piraeus-era `EbsPool` remnants and have been deleted, so the count is now literally zero.)

## What

`AwsDlm` emits one shared DLM execution role — `dlm.amazonaws.com` trust plus the `AWSDataLifecycleManagerServiceRole` managed policy — and a `LifecyclePolicy` per schedule. The role is shared because DLM's permissions are identical for every policy and AWS's own default role is an account singleton; a role per schedule would be noise with no isolation benefit.

```ts
new AwsDlm(chart, "dlm", {
  name: "stage",
  schedules: [{
    name: "data-daily",
    region: "eu-central-1",
    targetTags: { "nuconstruct.io/backup": "daily" },
    retain: 7,
  }],
});
```

Data volumes now carry a constant `<tagDomain>/backup: daily` marker; opt out with `dataVolume.snapshot: false`. The marker **has** to be constant: DLM `targetTags` match key AND value exactly, so the existing per-node `<tagDomain>/node: <name>` tag can never be a target. That asymmetry is the entire reason for a second tag rather than reusing the one already there.

Two config errors are rejected at synth rather than by the AWS API:
- an interval outside DLM's allowed set (`1,2,3,4,6,8,12,24`)
- empty `targetTags`, which would silently match **every** volume in the region

## Scope — read this bit

Snapshots are **crash-consistent**. DLM does not quiesce the filesystem. That is the right trade for chain data (the client replays its WAL on start) and is explicitly **not** an etcd backup, which needs `k0s etcd backup` semantics rather than a block-level copy. **etcd remains uncovered** — separate mechanism, separate change.

DLM rather than AWS Backup because this is EBS-only, tag-targeted, needs no vault, and the schedule is the whole feature. AWS Backup earns its extra surface (vaults, restore testing, cross-account) once there is something other than EBS to protect.

## Notes

`dlm` was already in the provider-family union with `dlm:*` in `CONTROLLER_POLICY_DOCUMENT` and the CRDs imported — only the construct was missing.

Nothing is snapshotted until a consumer instantiates `AwsDlm`; this PR ships the construct and the marker tag. Wiring it into DevOps needs the pinned `nebula-cdk8s` tarball bumped after this merges.

Verified by synthesizing the policy alongside a two-node fleet: `dlm.aws.upbound.io/v1beta2` LifecyclePolicy with the expected `policyDetails`, role + attachment, `backup: daily` present on the default node and absent on `snapshot: false`. Both guards throw. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)