### PR TITLE
aws/dlm: decouple the DLM schedule name from the MR name

### DIFF
--- a/packages/nebula/src/modules/infra/aws/dlm.ts
+++ b/packages/nebula/src/modules/infra/aws/dlm.ts
@@ -45,6 +45,16 @@ export interface DlmSnapshotSchedule {
   /** Schedule id. The LifecyclePolicy MR is named `<config.name>-<name>`, so
    *  this is also how an existing policy is adopted without churn. */
   name: string;
+  /**
+   * DLM's own name for the schedule (default: {@link name}).
+   *
+   * Distinct from the MR name because DLM stamps it onto every snapshot as
+   * `aws:dlm:lifecycle-schedule-name` and applies retention PER SCHEDULE
+   * NAME: renaming it strands the snapshots taken under the old name outside
+   * the retain count, so they are never pruned. Set this when adopting a
+   * policy whose schedule is already producing snapshots.
+   */
+  scheduleName?: string;
   /** DLM policy description. AWS restricts these to `[0-9A-Za-z _-]` — no
    *  punctuation. Defaults to the MR name, which is rarely what a human
    *  reading the AWS console wants. */
@@ -170,7 +180,7 @@ export class AwsDlm extends Construct {
               targetTags: s.targetTags,
               schedule: [
                 {
-                  name: s.name,
+                  name: s.scheduleName ?? s.name,
                   copyTags: s.copyTags ?? true,
                   createRule: {
                     interval,


### PR DESCRIPTION
Third and last piece needed to fold DevOps' `clusters/mgmt/ebs-backup` onto `AwsDlm` with genuinely zero churn.

DLM stamps the schedule name onto every snapshot as `aws:dlm:lifecycle-schedule-name`, and applies retention **per schedule name**. Renaming it strands every snapshot taken under the old name outside the retain count — they are never pruned and accumulate forever.

The MR name and the schedule name were the same field. Adopting a live policy whose MR name implies a different schedule name therefore orphaned its snapshots silently. The DevOps migration hits exactly that case: the MR must stay `mgmt-daily-snapshots` (or Crossplane deletes and recreates the policy) while the schedule must stay `daily`, under which **10 snapshots already exist** — including all three `kmc-*` etcd PVCs, taken at 03:18 today.

They are different things: one is k8s identity, the other an AWS label. They only ever coincided by accident.

`scheduleName` defaults to `name`, so nothing else changes. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)