### PR TITLE
worker-fleet: LaunchTemplate IMDS parity with the Instance path

### DIFF
--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -721,12 +721,22 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
               ],
             },
           ],
-          metadataOptions: [
-            {
-              httpTokens: "required",
-              ...(node.imdsPodAccess ? { httpPutResponseHopLimit: 2 } : {}),
-            },
-          ],
+          // IMDS parity with the Instance-MR path: metadataOptions are set
+          // ONLY for imdsPodAccess nodes (required tokens + hop limit 2, the
+          // keyless-controller posture). Everywhere else the EC2 defaults
+          // apply — httpTokens OPTIONAL matters: with tokens required at hop
+          // limit 1 a POD cannot obtain a token, so anything needing instance
+          // metadata dies (observed live: ebs-csi-node crashlooping
+          // "all specified --metadata-sources are unavailable", chain-data
+          // PVCs unmountable). Hardening IMDS fleet-wide is a separate
+          // decision that must pair hop limit 2 or a metadata proxy.
+          ...(node.imdsPodAccess
+            ? {
+                metadataOptions: [
+                  { httpTokens: "required", httpPutResponseHopLimit: 2 },
+                ],
+              }
+            : {}),
           blockDeviceMappings: [
             {
               deviceName: "/dev/sda1",


### PR DESCRIPTION
Regression from the ASG lifecycle: the LT forced IMDSv2 (`httpTokens: required`) on all nodes at hop limit 1, which locks pods out of IMDS — ebs-csi-node crashlooped and chain-data PVCs became unmountable. Restore parity: metadataOptions only for `imdsPodAccess` nodes.

Live fleet already remediated with `modify-instance-metadata-options` (CSI now 9/9 — it had silently been 2/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)