### PR TITLE
iam: let the controller role run SSM commands (self-diagnosis)

### DIFF
--- a/packages/nebula/src/modules/infra/aws/iam.ts
+++ b/packages/nebula/src/modules/infra/aws/iam.ts
@@ -54,6 +54,17 @@ const CONTROLLER_POLICY_DOCUMENT = JSON.stringify({
         "s3:*",
         "ssm:GetParameter",
         "ssm:GetParameters",
+        // Run-command access so an in-cluster pod on this role can read a
+        // node's journal (the nodes already carry
+        // AmazonSSMManagedInstanceCore). Without it, diagnosing a host that
+        // boots but never joins the cluster requires local AWS credentials —
+        // and the whole point of the keyless model is that the estate can
+        // debug and repair itself. No escalation in practice: this role
+        // already holds ec2:*/iam:*/elasticloadbalancing:*.
+        "ssm:DescribeInstanceInformation",
+        "ssm:SendCommand",
+        "ssm:GetCommandInvocation",
+        "ssm:ListCommandInvocations",
         "tag:GetResources",
         // servicequotas family (quota raises as code) and dlm family (EBS
         // snapshot lifecycle) 403 without these.


### PR DESCRIPTION
A host that boots but never joins can only be diagnosed from its journal, and the node role could not call SSM — so the credential-free debugging model failed exactly where it mattered. Nodes already have AmazonSSMManagedInstanceCore; this adds the caller half. Same role already holds ec2:*/iam:*.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)