### PR TITLE
member-monitoring: ephemeralStorage for node-local-only members

### DIFF
--- a/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
@@ -73,6 +73,19 @@ export interface MemberMonitoringConfig {
   /** Local Prometheus PVC size (defaults to 5Gi). */
   storageSize?: string;
   /**
+   * Back the local Prometheus with an emptyDir instead of a PVC, capped at
+   * {@link storageSize}.
+   *
+   * Set this on members whose only StorageClass is node-local. A node-local PV
+   * carries a nodeAffinity naming the node it was provisioned on; when that
+   * node is replaced the PV still names the dead one, the pod becomes
+   * unschedulable ("didn't match PersistentVolume's node affinity"), and the
+   * StatefulSet stays wedged until a human deletes the PVC — which is exactly
+   * what a member has nothing to lose from. Its history lives in the central
+   * sink; the local disk is a remote_write buffer.
+   */
+  ephemeralStorage?: boolean;
+  /**
    * External labels stamped on every series (and, by default, every Promtail
    * log stream) so this producer is distinguishable in the shared central
    * sink, e.g. { cluster: "dev-aws", env: "dev" }.
@@ -131,11 +144,13 @@ export class MemberMonitoring extends BaseConstruct<MemberMonitoringConfig> {
       prometheus: {
         prometheusSpec: {
           retention,
-          storageSpec: {
-            volumeClaimTemplate: {
-              spec: { resources: { requests: { storage: storageSize } } },
-            },
-          },
+          storageSpec: this.config.ephemeralStorage
+            ? { emptyDir: { sizeLimit: storageSize } }
+            : {
+                volumeClaimTemplate: {
+                  spec: { resources: { requests: { storage: storageSize } } },
+                },
+              },
           externalLabels: this.config.externalLabels,
           remoteWrite: [
             {


### PR DESCRIPTION
A member cluster whose only StorageClass is node-local cannot survive a worker replacement with a PVC-backed Prometheus. The PV keeps a `nodeAffinity` naming the node it was provisioned on, so once that node is gone the pod is permanently unschedulable and only a human deleting the PVC recovers it.

cicd has been in exactly that state: its PV names `cicd-amd64-c8vzs-jcssc`, a node from a MachineSet that no longer exists, and `cicd-monitoring` has been Degraded ever since.

A member has nothing on that disk worth pinning a pod for — history lives in the central sink, the local volume is a remote_write buffer. `ephemeralStorage: true` renders `storageSpec.emptyDir.sizeLimit` at the same `storageSize`, so the buffer stays bounded and the pod is free to land anywhere.

Not defaulted on: members backed by network storage (stage uses gp3/EBS-CSI) keep their buffer across restarts and should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)