### PR TITLE
k0smotron pools: state --node-ip on dual-stack workers

### DIFF
--- a/packages/nebula/src/modules/infra/k0s/cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/cluster.ts
@@ -174,6 +174,55 @@ export const DEFAULT_PRESTART_COMMANDS: readonly string[] = [
   "systemctl enable --now iscsid || true",
 ];
 
+/**
+ * preK0sCommands recording the node's own addresses for `--node-ip`, keyed off
+ * the default-route interface so no metadata service is involved.
+ *
+ * Required on every DUAL-STACK worker from k0s 1.35 on. Given a dual-stack
+ * cluster and no explicit `--node-ip`, the worker resolves the kubelet's node
+ * NAME through DNS and demands one address of each family back
+ * (k0sproject/k0s#5840, pkg/component/worker/kubelet.go). Under Cluster API
+ * the node name is the Machine name, which is in no DNS zone, so the lookup
+ * returns nothing and k0s exits before the kubelet ever contacts the API
+ * server:
+ *
+ *   failed to detect node IPs for "cicd-amd64-sgxxq-nmfpt":
+ *   lookup cicd-amd64-sgxxq-nmfpt on 127.0.0.53:53: server misbehaving
+ *
+ * k0s 1.34 only logged that failure. Passing the addresses is upstream's own
+ * documented way out, and it is per-node without a per-node template: the
+ * substitutions run on the node, and `k0s install worker` bakes the resolved
+ * literals into the systemd unit.
+ *
+ * The v6 GUA arrives by RA/DHCPv6, so that read waits for it instead of
+ * assuming it has landed by the time cloud-init reaches this point.
+ */
+export const NODE_IP_DISCOVERY_COMMANDS: readonly string[] = [
+  `sh -c 'IFACE=$(ip route show default | awk "{print \\$5}" | head -1); ip -4 addr show dev "$IFACE" scope global | awk "/inet /{print \\$2; exit}" | cut -d/ -f1 > /run/node-ip'`,
+  `sh -c 'IFACE=$(ip route show default | awk "{print \\$5}" | head -1); for i in $(seq 1 30); do IP6=$(ip -6 addr show dev "$IFACE" scope global 2>/dev/null | awk "/inet6/{print \\$2; exit}" | cut -d/ -f1); [ -n "$IP6" ] && break; sleep 2; done; echo "$IP6" > /run/node-ip6'`,
+];
+
+/**
+ * Add `--node-ip` (from {@link NODE_IP_DISCOVERY_COMMANDS}) to a worker's k0s
+ * args, folding it into an existing `--kubelet-extra-args` rather than adding
+ * a second one — k0s keeps only the last occurrence, so a naive append would
+ * discard whatever the pool had set. A pool that already states `--node-ip`
+ * is left alone.
+ */
+export function withNodeIpArgs(args: string[], v6First = false): string[] {
+  const nodeIp = v6First
+    ? "--node-ip=$(cat /run/node-ip6),$(cat /run/node-ip)"
+    : "--node-ip=$(cat /run/node-ip),$(cat /run/node-ip6)";
+  const prefix = "--kubelet-extra-args=";
+  const i = args.findIndex((a) => a.startsWith(prefix));
+  if (i < 0) return [...args, `${prefix}"${nodeIp}"`];
+  const existing = args[i].slice(prefix.length).replace(/^"|"$/g, "");
+  if (existing.includes("--node-ip=")) return args;
+  const merged = [...args];
+  merged[i] = `${prefix}"${nodeIp} ${existing}"`;
+  return merged;
+}
+
 /** Render `k0s worker` --labels/--taints args from a pool's labels/taints. */
 export function renderK0sWorkerArgs<M>(pool: K0sWorkerPool<M>): string[] {
   const args: string[] = [];

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
@@ -9,7 +9,9 @@ import {
 } from "#imports/controlplane.cluster.x-k8s.io";
 import {
   DEFAULT_PRESTART_COMMANDS,
+  NODE_IP_DISCOVERY_COMMANDS,
   renderK0sWorkerArgs,
+  withNodeIpArgs,
   type K0sInfraProvider,
   type K0sWorkerPool,
 } from "./cluster";
@@ -187,7 +189,13 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
       );
 
       const workerConfigName = `${name}-${poolName}-config`;
-      const wargs = renderK0sWorkerArgs(pool);
+      // Dual-stack workers must state their own --node-ip from k0s 1.35 on —
+      // see NODE_IP_DISCOVERY_COMMANDS for why name-based detection cannot
+      // work under Cluster API.
+      const dualStack = this.config.dualStack !== undefined;
+      const wargs = dualStack
+        ? withNodeIpArgs(renderK0sWorkerArgs(pool))
+        : renderK0sWorkerArgs(pool);
       new K0sWorkerConfigTemplateV1Beta2(this, `worker-config-${poolName}`, {
         metadata: { name: workerConfigName, namespace },
         spec: {
@@ -197,6 +205,7 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
               ...(wargs.length ? { args: wargs } : {}),
               preK0SCommands: [
                 ...DEFAULT_PRESTART_COMMANDS,
+                ...(dualStack ? NODE_IP_DISCOVERY_COMMANDS : []),
                 ...(pool.extraPreStartCommands ?? []),
               ],
             },


### PR DESCRIPTION
### What broke

k0s 1.35 turned a previously-logged failure into a fatal one. With `spec.network.dualStack.enabled` and no explicit `--node-ip`, the worker resolves the kubelet's node **name** through DNS and requires one address of each family back — [`pkg/component/worker/kubelet.go`](https://github.com/k0sproject/k0s/blob/v1.35.7%2Bk0s.0/pkg/component/worker/kubelet.go#L115-L132), introduced by [k0s#5840](https://github.com/k0sproject/k0s/pull/5840) (`efac0a7f`, Dec 2025).

Under Cluster API the node name is the Machine name, which is in no DNS zone, so the worker exits before the kubelet ever contacts the API server:

```
failed to detect node IPs for "cicd-amd64-sgxxq-nmfpt":
lookup cicd-amd64-sgxxq-nmfpt on 127.0.0.53:53: server misbehaving
```

1.34 logged that and started kubelet anyway, which is why cicd works at 1.34.10 and stalls at 1.35.7.

### Why this fix

- The commit is not in `release-1.34` and is present in every `release-1.35` tag through 1.35.7 (latest); `main` still has it. There is no fixed patch release to wait for.
- No k0s worker flag, env var, feature gate, or `KubeletConfiguration` field can disable it. `--node-ip=` with an empty value does not satisfy the guard, and `--node-ip=0.0.0.0,::` is rejected by kubelet.
- Passing real addresses is upstream's own documented escape hatch.

The self-assembling AWS fleet has passed `--node-ip` since the v6 identity flip — that is why stage never hit this and only the k0smotron worker pools did. This gives them the same treatment.

### Mechanics

`NODE_IP_DISCOVERY_COMMANDS` reads both addresses off the default-route interface (waiting for the RA/DHCPv6 GUA) into `/run/node-ip` and `/run/node-ip6`; `withNodeIpArgs` folds `--node-ip=$(cat ...),$(cat ...)` into `--kubelet-extra-args`, merging with an existing one rather than adding a second (k0s keeps only the last). One template still serves a whole pool: the substitutions run on the node and `k0s install worker` bakes the literals into the systemd unit.

Verified on a live cicd worker via SSM — the two commands yield `--node-ip=10.1.200.179,2a05:d014:a7d:d002:72bd:e661:c8c9:6690`, matching that node's ens5 addresses.

Only emitted when `dualStack` is set; single-stack pools are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)