### PR TITLE
prometheus-operator: emptyDir and PVC template are exclusive

### DIFF
--- a/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
@@ -158,6 +158,12 @@ export interface PrometheusOperatorConfig {
   repository?: string;
   /** Storage class name for persistent volumes (defaults to standard) */
   storageClassName?: string;
+  /**
+   * Back Prometheus with an emptyDir of this size instead of a PVC. Mutually
+   * exclusive with the PVC template — a `spec.storage` carrying both leaves
+   * the reader guessing which one the operator honours.
+   */
+  ephemeralStorage?: { sizeLimit: string };
   /** Additional Helm values */
   values?: Record<string, unknown>;
   /** Loki configuration */
@@ -328,15 +334,19 @@ export class PrometheusOperator extends HelmModule<PrometheusOperatorConfig> {
             ? { enableRemoteWriteReceiver: true }
             : {}),
           retention: thanosEnabled ? "24h" : "30d",
-          storageSpec: {
-            volumeClaimTemplate: {
-              spec: {
-                storageClassName: storageClassName,
-                accessModes: ["ReadWriteOnce"],
-                resources: { requests: { storage: thanosEnabled ? "20Gi" : "50Gi" } },
+          storageSpec: this.config.ephemeralStorage
+            ? { emptyDir: this.config.ephemeralStorage }
+            : {
+                volumeClaimTemplate: {
+                  spec: {
+                    storageClassName: storageClassName,
+                    accessModes: ["ReadWriteOnce"],
+                    resources: {
+                      requests: { storage: thanosEnabled ? "20Gi" : "50Gi" },
+                    },
+                  },
+                },
               },
-            },
-          },
           serviceMonitorSelectorNilUsesHelmValues: false,
           ruleSelectorNilUsesHelmValues: false,
           podMonitorSelectorNilUsesHelmValues: false,

--- a/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
@@ -144,13 +144,18 @@ export class MemberMonitoring extends BaseConstruct<MemberMonitoringConfig> {
       prometheus: {
         prometheusSpec: {
           retention,
-          storageSpec: this.config.ephemeralStorage
-            ? { emptyDir: { sizeLimit: storageSize } }
+          // The emptyDir case is set on the wrapped module instead — a
+          // storageSpec merged in here would land ALONGSIDE the PVC template
+          // the module always emits, not replace it.
+          ...(this.config.ephemeralStorage
+            ? {}
             : {
-                volumeClaimTemplate: {
-                  spec: { resources: { requests: { storage: storageSize } } },
+                storageSpec: {
+                  volumeClaimTemplate: {
+                    spec: { resources: { requests: { storage: storageSize } } },
+                  },
                 },
-              },
+              }),
           externalLabels: this.config.externalLabels,
           remoteWrite: [
             {
@@ -204,6 +209,9 @@ export class MemberMonitoring extends BaseConstruct<MemberMonitoringConfig> {
       ...(this.config.version ? { version: this.config.version } : {}),
       ...(this.config.storageClassName
         ? { storageClassName: this.config.storageClassName }
+        : {}),
+      ...(this.config.ephemeralStorage
+        ? { ephemeralStorage: { sizeLimit: storageSize } }
         : {}),
       ...(tolerations ? { tolerations } : {}),
       // No local Loki — logs go to the central sink (or nowhere).


### PR DESCRIPTION
Follow-up to #104. Setting `ephemeralStorage` through the member's Helm values deep-merged the emptyDir *alongside* the PVC template the base module always emits:

```yaml
storage:
  emptyDir:
    sizeLimit: 5Gi
  volumeClaimTemplate:
    spec:
      storageClassName: standard-rwo
      resources: { requests: { storage: 50Gi } }
```

prometheus-operator does check `EmptyDir` before the PVC, so it behaved correctly — but the rendered CR left the reader guessing which one applied, and anyone deciding it looked wrong would have "fixed" it back.

The choice now lives in the base module, where the PVC template is written, so exactly one of the two is ever emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)