### PR TITLE
worker: drop the instance-lifecycle machinery

### DIFF
--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -1,15 +1,24 @@
 /**
  * Worker fleet — the git-side half of the ONE node unit for every cluster
  * node, in every region (pairs with the k0s {@link Worker} composition, which
- * derives the runtime bindings: pooled SSH inventory + instance-id-named
- * EIPAssociation/VolumeAttachment followers).
+ * turns the node's observed EIP into pooled SSH inventory).
  *
  * A node is NOT a CAPI machine: each is a 1:1 Crossplane resource group
- * (Instance + Eip + optional data EBSVolume) adopted via a per-node
- * MachineDeployment (replicas 1) over k0smotron's pooled RemoteMachine
- * provider — the owner an MHC needs to actually remediate. No token, no
- * address and no k0s install logic lives in git: userData is only host
- * identity + storage + the provisioner's SSH key.
+ * (LaunchTemplate + size-1 AutoscalingGroup + Eip + optional data EBSVolume)
+ * adopted via a per-node MachineDeployment (replicas 1) over k0smotron's
+ * pooled RemoteMachine provider — the owner an MHC needs to actually
+ * remediate. No token, no address and no k0s install logic lives in git:
+ * userData is only host identity + storage + the provisioner's SSH key.
+ *
+ * The EC2 instance is owned by a NAME-KEYED AutoscalingGroup, never a per-node
+ * Instance MR. Creation is then idempotent at AWS — a create retry hits
+ * AlreadyExists instead of launching a second instance, which is the whole
+ * RunInstances duplicate class (a provider hard-killed mid-async-create
+ * records a wrong outcome and the retry duplicates; no idempotency token
+ * reaches RunInstances through terraform — observed live 2026-08-02). Spot
+ * capacity also self-replaces with no control-plane involvement, and the node
+ * claims its own EIP and data volume at boot from the node role, so no
+ * follower MR is derived from an instance id.
  *
  * Regions are public-subnet + IGW only (nodes carry EIPs for the SSH
  * entrance; egress goes straight out — no NAT gateways). Subnets are the
@@ -161,20 +170,6 @@ export interface AwsWorkerFleetNode {
   /** Instance profile override (e.g. the controller-policy profile on system
    *  nodes; everything else gets the fleet's SSM-only role). */
   iamProfile?: string;
-  /**
-   * Who owns the EC2 instance's lifecycle.
-   * "instance" (default): a per-node Instance MR — adoption model; carries
-   * the RunInstances duplicate class (a provider hard-killed mid-async-create
-   * records a WRONG outcome and the retry duplicates; no idempotency token
-   * reaches RunInstances through terraform — observed live 2026-08-02).
-   * "asg": a name-keyed LaunchTemplate + size-1 AutoscalingGroup — creation
-   * is idempotent AT AWS (a retry hits AlreadyExists, never a duplicate),
-   * spot capacity self-replaces without any control-plane involvement, and
-   * the node self-assembles its EIP + data volume at boot via the node role
-   * (no Instance MR, no follower MRs). Requires allocationId; a data volume
-   * must be an adopted volumeId (createFresh unsupported).
-   */
-  lifecycle?: "instance" | "asg";
 }
 
 const DEFAULT_OPEN_PORTS: AwsWorkerFleetPort[] = [
@@ -272,11 +267,10 @@ export class AwsWorkerFleet extends Construct {
         providerConfigRef: this.pcRef,
       },
     });
-    // Boot self-assembly (asg-lifecycle nodes claim their EIP/data volume
-    // with their own role over IMDS). Associate/attach cannot be
-    // resource-scoped without per-call tag conditions the boot script cannot
-    // guarantee; the action list is the whole grant. Attached always —
-    // inert for instance-lifecycle nodes.
+    // Boot self-assembly: the node claims its EIP and data volume with its
+    // own role over IMDS. Associate/attach cannot be resource-scoped without
+    // per-call tag conditions the boot script cannot guarantee, so the action
+    // list is the whole grant.
     const selfAssemblyPolicyName = `${roleName}-self-assembly`;
     new Policy(this, "worker-node-self-assembly-policy", {
       metadata: { name: selfAssemblyPolicyName },
@@ -581,12 +575,12 @@ chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys
 chmod 600 /home/ubuntu/.ssh/authorized_keys
 retry() { n=0; until "$@"; do n=$((n+1)); [ "$n" -ge 30 ] && return 1; sleep 10; done; }
 retry apt-get update -qq
-retry apt-get install -y -qq lvm2 curl${node.lifecycle === "asg" ? " awscli" : ""}
-${node.lifecycle === "asg" ? this.selfAssemblySection(node, region) : ""}${lvmSection}`;
+retry apt-get install -y -qq lvm2 curl awscli
+${this.selfAssemblySection(node, region)}${lvmSection}`;
   }
 
   /**
-   * asg-lifecycle boot self-assembly: the node claims its own identity with
+   * Boot self-assembly: the node claims its own identity with
    * the node role over IMDS — EIP association FIRST (the provisioner's SSH
    * entrance rides it), then source/dest-check off (parity with the Instance
    * MR render), then the data volume. Every call retries: on replacement the
@@ -651,30 +645,21 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
         },
       });
     }
-    if (node.lifecycle === "asg") {
-      if (!node.allocationId)
-        throw new Error(`${node.name}: asg lifecycle requires allocationId`);
-      if (dv && !("volumeId" in dv && dv.volumeId))
-        throw new Error(
-          `${node.name}: asg lifecycle requires an adopted dataVolume.volumeId`,
-        );
-      this.addAsgNode(region, node, iamProfile);
-    } else {
-      this.addInstanceNode(region, node, iamProfile);
-    }
+    if (!node.allocationId)
+      throw new Error(`${node.name}: a worker node requires allocationId`);
+    if (dv && !("volumeId" in dv && dv.volumeId))
+      throw new Error(
+        `${node.name}: a worker node's dataVolume must be an adopted volumeId`,
+      );
+    this.addAsgNode(region, node, iamProfile);
 
     // --- CAPI adoption -----------------------------------------------------
-    // Worker (nebula) observes this node's Eip (+ Instance, when one exists)
-    // and publishes a PooledRemoteMachine into a POOL OF ONE plus any
-    // instance-id-derived follower MRs. asg-lifecycle nodes pass NO
-    // instanceName: the composition's Required gating then composes neither
-    // the Instance observer nor the followers — the node self-assembled its
-    // bindings at boot.
+    // Worker (nebula) observes this node's Eip for its public address and
+    // publishes a PooledRemoteMachine into a POOL OF ONE. Nothing else is
+    // derived from the control plane: the node claimed its EIP and data
+    // volume itself at boot, from the node role.
     new Worker(this, node.name, {
       eipName: node.eipName ?? node.name,
-      ...(node.lifecycle === "asg" ? {} : { instanceName: node.name }),
-      region: region.region,
-      ...(node.lifecycle === "asg" ? {} : { dataVolumeName: dataVolumeMrName }),
       sshSecretName: o.sshSecretName,
     });
     this.addCapiAdoption(region, node);
@@ -805,65 +790,6 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
     });
   }
 
-  /** adoption-model lifecycle: the per-node Instance MR (see the duplicate-
-   *  class caveat on {@link AwsWorkerFleetNode.lifecycle}). */
-  private addInstanceNode(
-    region: AwsWorkerFleetRegion,
-    node: AwsWorkerFleetNode,
-    iamProfile: string,
-  ) {
-    const o = this.options;
-    const p = this.prefix(region);
-    new ApiObject(this, `${node.name}-instance`, {
-      apiVersion: "ec2.aws.upbound.io/v1beta2",
-      kind: "Instance",
-      metadata: { name: node.name },
-      spec: {
-        deletionPolicy: "Delete",
-        // Replacement is done by DELETING the MR/Machine, since OWNED_POLICIES
-        // keeps Update off; userDataReplaceOnChange below is inert under that
-        // policy and kept only to document intent for the create path.
-        managementPolicies: OWNED_POLICIES,
-        forProvider: {
-          region: region.region,
-          ami: node.ami,
-          instanceType: node.instanceType,
-          // resolve Always: an AZ move replaces the subnet, and a frozen
-          // resolved id would wedge instance creation on the dead subnet.
-          subnetIdRef: { name: `${p}-subnet`, policy: { resolve: "Always", resolution: "Required" } },
-          vpcSecurityGroupIdRefs: [
-            { name: `${p}-sg`, policy: { resolve: "Always", resolution: "Required" } },
-          ],
-          iamInstanceProfile: node.iamProfile ?? iamProfile,
-          sourceDestCheck: false,
-          associatePublicIpAddress: true,
-          ipv6AddressCount: 1,
-          ...(node.imdsPodAccess
-            ? {
-                // Hop limit 2 exposes the node role to pods over IMDS —
-                // keyless AWS controllers. System nodes ONLY.
-                metadataOptions: { httpTokens: "required", httpPutResponseHopLimit: 2 },
-              }
-            : {}),
-          rootBlockDevice: {
-            volumeSize: node.rootVolumeGi ?? 100,
-            volumeType: "gp3",
-            encrypted: true,
-          },
-          ...(node.spot ? { instanceMarketOptions: { marketType: "spot" } } : {}),
-          userData: this.userData(node, region),
-          userDataReplaceOnChange: true,
-          tags: {
-            Name: node.name,
-            [`${o.tagDomain}/geo`]: region.geo,
-            [`${o.tagDomain}/purpose`]: o.eipPurpose,
-          },
-        },
-        providerConfigRef: this.pcRef,
-      },
-    });
-
-  }
 
   /**
    * Per-node MachineDeployment (replicas 1) over RemoteMachineTemplate +

--- a/packages/nebula/src/modules/infra/k0s/cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/cluster.ts
@@ -165,13 +165,19 @@ export interface K0sClusterConfig<M> {
 }
 
 /**
- * Default cloud-init preStartCommands (storage deps for Piraeus/LINSTOR),
- * shared by the control-plane and every worker pool.
+ * Default cloud-init preStartCommands, shared by the control-plane and every
+ * worker pool.
+ *
+ * Deliberately just the inotify limits. This used to also `apt-get install`
+ * linux-headers + lvm2 + thin-provisioning-tools + open-iscsi + cryptsetup and
+ * enable iscsid, for a Piraeus/LINSTOR stack that no longer exists anywhere in
+ * the estate — every node paid an archive fetch and a kernel-header install at
+ * boot for a DRBD transport nothing was going to use. A pool that genuinely
+ * needs host storage packages asks for them through `extraPreStartCommands`,
+ * where the reason is visible next to the cluster that has it.
  */
 export const DEFAULT_PRESTART_COMMANDS: readonly string[] = [
   "sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=8192",
-  "apt-get update -qq && apt-get install -y -qq linux-headers-$(uname -r) lvm2 thin-provisioning-tools open-iscsi cryptsetup",
-  "systemctl enable --now iscsid || true",
 ];
 
 /**
@@ -209,10 +215,8 @@ export const NODE_IP_DISCOVERY_COMMANDS: readonly string[] = [
  * discard whatever the pool had set. A pool that already states `--node-ip`
  * is left alone.
  */
-export function withNodeIpArgs(args: string[], v6First = false): string[] {
-  const nodeIp = v6First
-    ? "--node-ip=$(cat /run/node-ip6),$(cat /run/node-ip)"
-    : "--node-ip=$(cat /run/node-ip),$(cat /run/node-ip6)";
+export function withNodeIpArgs(args: string[]): string[] {
+  const nodeIp = "--node-ip=$(cat /run/node-ip),$(cat /run/node-ip6)";
   const prefix = "--kubelet-extra-args=";
   const i = args.findIndex((a) => a.startsWith(prefix));
   if (i < 0) return [...args, `${prefix}"${nodeIp}"`];

--- a/packages/nebula/src/modules/infra/k0s/worker.ts
+++ b/packages/nebula/src/modules/infra/k0s/worker.ts
@@ -35,7 +35,7 @@
  * - `Worker` — an XR instance (one per node)
  *
  * Prerequisites: provider-kubernetes (ProviderConfig + RBAC to read
- * eips/instances/ebsvolumes.ec2.aws.upbound.io), function-patch-and-transform,
+ * eips.ec2.aws.upbound.io), function-patch-and-transform,
  * function-auto-ready, and Crossplane RBAC to manage
  * pooledremotemachines.infrastructure.cluster.x-k8s.io.
  */
@@ -48,24 +48,11 @@ import {
   CompositionSpecMode,
 } from "#imports/apiextensions.crossplane.io";
 import { ARGOCD_SYNC_WAVE_ANNOTATION } from "../../../core";
-import {
-  FOLLOWER_POLICIES,
-  OBSERVE_POLICIES,
-} from "../../../utils/crossplane-policies";
+import { OBSERVE_POLICIES } from "../../../utils/crossplane-policies";
 
 export interface WorkerConfig {
   /** metadata.name of the Eip managed resource to observe (cluster-scoped). */
   eipName: string;
-  /** metadata.name of the Instance managed resource to observe. Omit for
-   *  self-assembled (ASG-lifecycle) nodes: no observer and no
-   *  instance-id-derived followers are composed. */
-  instanceName?: string;
-  /** AWS region for the composed follower MRs (EIPAssociation/VolumeAttachment). */
-  region: string;
-  /** metadata.name of the data EBSVolume MR. Omit for nodes without one. */
-  dataVolumeName?: string;
-  /** Device name for the data-volume attachment (default "/dev/sdf"). */
-  deviceName?: string;
   /** Pool name the git-side RemoteMachine reserves from (default: the XR id). */
   pool?: string;
   /** Namespace for the PooledRemoteMachine (default "default"). */
@@ -155,8 +142,6 @@ export class WorkerSetup extends Construct {
                     type: "object",
                     required: [
                       "eipName",
-                      "region",
-                      "deviceName",
                       "pool",
                       "namespace",
                       "sshSecretName",
@@ -169,23 +154,6 @@ export class WorkerSetup extends Construct {
                       eipName: {
                         type: "string",
                         description: "Eip managed-resource name to observe",
-                      },
-                      instanceName: {
-                        type: "string",
-                        description: "Instance managed-resource name to observe",
-                      },
-                      region: {
-                        type: "string",
-                        description: "AWS region for composed follower MRs",
-                      },
-                      dataVolumeName: {
-                        type: "string",
-                        description:
-                          "Data EBSVolume MR name (omit: no attachment composed)",
-                      },
-                      deviceName: {
-                        type: "string",
-                        description: "Data-volume attachment device name",
                       },
                       pool: {
                         type: "string",
@@ -224,14 +192,6 @@ export class WorkerSetup extends Construct {
                         type: "string",
                         description: "Allocation id observed from the Eip",
                       },
-                      instanceId: {
-                        type: "string",
-                        description: "Id observed from the Instance",
-                      },
-                      volumeId: {
-                        type: "string",
-                        description: "Id observed from the data EBSVolume",
-                      },
                     },
                   },
                 },
@@ -242,11 +202,7 @@ export class WorkerSetup extends Construct {
       },
     });
 
-    // Two variants: a Required-skipped composed resource keeps the XR in
-    // Ready=False/Creating forever (observed live on every data-less node),
-    // so nodes without a data volume SELECT a composition without the volume
-    // pair instead of skipping it at patch time.
-    const baseResources: object[] = [
+    const resources: object[] = [
                 {
                   name: "eip",
                   base: observeBase("EIP"),
@@ -272,30 +228,7 @@ export class WorkerSetup extends Construct {
                     },
                   ],
                 },
-                {
-                  name: "instance",
-                  base: observeBase("Instance"),
-                  patches: [
-                    // Required gates the whole observer: a self-assembled
-                    // (ASG-lifecycle) node has NO Instance MR — omitting
-                    // instanceName composes no observer, status.instanceId
-                    // never fills, and every instance-id-gated follower
-                    // self-gates out downstream.
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "spec.instanceName",
-                      toFieldPath: "spec.forProvider.manifest.metadata.name",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                    providerConfigPatch,
-                    {
-                      type: "ToCompositeFieldPath",
-                      fromFieldPath:
-                        "status.atProvider.manifest.status.atProvider.id",
-                      toFieldPath: "status.instanceId",
-                    },
-                  ],
-                },
+
                 {
                   name: "pooled-machine",
                   base: {
@@ -365,166 +298,10 @@ export class WorkerSetup extends Construct {
                     },
                   ],
                 },
-                {
-                  name: "eip-association",
-                  base: {
-                    apiVersion: "ec2.aws.upbound.io/v1beta1",
-                    kind: "EIPAssociation",
-                    metadata: { name: "placeholder" },
-                    spec: {
-                      managementPolicies: FOLLOWER_POLICIES,
-                      forProvider: {
-                        region: "placeholder",
-                        allowReassociation: true,
-                      },
-                    },
-                  },
-                  patches: [
-                    // Gate on the SPEC field, not just status.instanceId:
-                    // once an asg-lifecycle node stops composing the Instance
-                    // observer, status.instanceId FREEZES at the last
-                    // observed (now-terminated) id — nothing is left to clear
-                    // it — so a status-only gate keeps composing followers
-                    // against a dead instance forever (observed live: 9
-                    // permanently Synced=False EIPAssociations that returned
-                    // seconds after deletion). Absent spec.instanceName =>
-                    // Required patch fails => the whole follower is skipped.
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "spec.instanceName",
-                      toFieldPath: "metadata.labels[\"k0s.nuconstruct.io/instance-mr\"]",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                    // Name from the observed instance id: replacement composes
-                    // a fresh association and garbage-collects the stale one —
-                    // never an in-place instance_id update for upjet to refuse.
-                    {
-                      type: "CombineFromComposite",
-                      combine: {
-                        variables: [
-                          { fromFieldPath: "metadata.name" },
-                          { fromFieldPath: "status.instanceId" },
-                        ],
-                        strategy: "string",
-                        string: { fmt: "%s-%s" },
-                      },
-                      toFieldPath: "metadata.name",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "spec.region",
-                      toFieldPath: "spec.forProvider.region",
-                    },
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "status.allocationId",
-                      toFieldPath: "spec.forProvider.allocationId",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "status.instanceId",
-                      toFieldPath: "spec.forProvider.instanceId",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                  ],
-                },
     ];
-    const volumeResources: object[] = [
-                {
-                  name: "data-volume",
-                  base: observeBase("EBSVolume"),
-                  patches: [
-                    // Required gates the whole Object: a node without a data
-                    // volume composes no observer (and so no attachment).
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "spec.dataVolumeName",
-                      toFieldPath: "spec.forProvider.manifest.metadata.name",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                    providerConfigPatch,
-                    {
-                      type: "ToCompositeFieldPath",
-                      fromFieldPath:
-                        "status.atProvider.manifest.status.atProvider.id",
-                      toFieldPath: "status.volumeId",
-                    },
-                  ],
-                },
-                {
-                  name: "volume-attachment",
-                  base: {
-                    apiVersion: "ec2.aws.upbound.io/v1beta1",
-                    kind: "VolumeAttachment",
-                    metadata: { name: "placeholder" },
-                    spec: {
-                      managementPolicies: FOLLOWER_POLICIES,
-                      forProvider: {
-                        region: "placeholder",
-                        deviceName: "placeholder",
-                      },
-                    },
-                  },
-                  patches: [
-                    // Gate on the SPEC field, not just status.instanceId:
-                    // once an asg-lifecycle node stops composing the Instance
-                    // observer, status.instanceId FREEZES at the last
-                    // observed (now-terminated) id — nothing is left to clear
-                    // it — so a status-only gate keeps composing followers
-                    // against a dead instance forever (observed live: 9
-                    // permanently Synced=False EIPAssociations that returned
-                    // seconds after deletion). Absent spec.instanceName =>
-                    // Required patch fails => the whole follower is skipped.
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "spec.instanceName",
-                      toFieldPath: "metadata.labels[\"k0s.nuconstruct.io/instance-mr\"]",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                    {
-                      type: "CombineFromComposite",
-                      combine: {
-                        variables: [
-                          { fromFieldPath: "metadata.name" },
-                          { fromFieldPath: "status.instanceId" },
-                        ],
-                        strategy: "string",
-                        string: { fmt: "%s-data-%s" },
-                      },
-                      toFieldPath: "metadata.name",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "spec.region",
-                      toFieldPath: "spec.forProvider.region",
-                    },
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "spec.deviceName",
-                      toFieldPath: "spec.forProvider.deviceName",
-                    },
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "status.volumeId",
-                      toFieldPath: "spec.forProvider.volumeId",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                    {
-                      type: "FromCompositeFieldPath",
-                      fromFieldPath: "status.instanceId",
-                      toFieldPath: "spec.forProvider.instanceId",
-                      policy: { fromFieldPath: "Required" },
-                    },
-                  ],
-                },
-    ];
-    const mkComposition = (id: string, name: string, resources: object[]) =>
-      new Composition(this, id, {
+    this.composition = new Composition(this, "composition", {
         metadata: {
-          name,
+          name: "worker",
           annotations: { [ARGOCD_SYNC_WAVE_ANNOTATION]: "-5" },
         },
         spec: {
@@ -549,12 +326,7 @@ export class WorkerSetup extends Construct {
             },
           ],
         },
-      });
-    this.composition = mkComposition("composition", "worker", [
-      ...baseResources,
-      ...volumeResources,
-    ]);
-    mkComposition("composition-basic", "worker-basic", baseResources);
+    });
   }
 }
 
@@ -572,18 +344,8 @@ export class Worker extends Construct {
       spec: {
         // v2 XRD: machinery fields nest under spec.crossplane — a top-level
         // compositionRef is silently pruned by the structural schema.
-        crossplane: {
-          compositionRef: {
-            name: config.dataVolumeName ? "worker" : "worker-basic",
-          },
-        },
+        crossplane: { compositionRef: { name: "worker" } },
         eipName: config.eipName,
-        ...(config.instanceName ? { instanceName: config.instanceName } : {}),
-        region: config.region,
-        ...(config.dataVolumeName
-          ? { dataVolumeName: config.dataVolumeName }
-          : {}),
-        deviceName: config.deviceName ?? "/dev/sdf",
         pool: config.pool ?? id,
         namespace: config.namespace ?? "default",
         sshSecretName: config.sshSecretName,


### PR DESCRIPTION
Nothing in the estate has used it since the fleet moved to name-keyed LaunchTemplate + size-1 AutoscalingGroup nodes: zero `Instance` MRs exist, all nine stage nodes are ASG-owned, and `lifecycle: "instance"` appears nowhere in git.

What remained was not merely unused — **it was the mode that leaks**. A provider hard-killed mid-async-create records a wrong outcome and the retry duplicates, because no idempotency token reaches `RunInstances` through terraform (observed live 2026-08-02: three instances for one MR). Keeping it selectable keeps that footgun loaded.

It was also **actively producing garbage**. The Instance observer lived in the composition's base resource list, so `worker-basic` — the variant every data-less node selects — composed it even for ASG nodes, where `spec.instanceName` is absent. The `Required` gate does not skip the resource; it leaves the base's `placeholder` name in place. Result: nine Objects permanently reporting `observe failed: external resource does not exist`, recreated on every delete. The existing two-variant split was this same problem, already solved once, for the volume pair only.

**Removed:** Instance + EBSVolume observers, EIPAssociation + VolumeAttachment followers, `addInstanceNode`, the `lifecycle` option, and the XRD fields that only fed them (`instanceName`, `dataVolumeName`, `deviceName`, `region`, `status.instanceId`, `status.volumeId`). One resource pair is left — observe the Eip for its address, publish a `PooledRemoteMachine` — so the two compositions collapse into one and `worker-basic` goes away.

**Also:** drops the boot-time `apt-get install` of `linux-headers-$(uname -r) lvm2 thin-provisioning-tools open-iscsi cryptsetup` (and `systemctl enable --now iscsid`) from the shared preStartCommands. Those were Piraeus/LINSTOR dependencies; that stack is retired, stage's OpenEBS uses plain LVM (`storage: lvm`, no thin pools), and no cluster runs iSCSI or DRBD. Every node was fetching the archive and installing kernel headers at boot for nothing.

### Verification

`argocd app diff cluster-stage --revision <this>` against the live cluster:

```
===== CompositeResourceDefinition /xworkers.nebula.io ======   (dead fields removed)
===== Composition /worker ======                               (4 resources removed)
===== Composition /worker-basic ======                         (gone)
===== XWorker /stage-* (x9) ======
  146c146
  <       name: worker-basic
  ---
  >       name: worker
```

No `LaunchTemplate`, `AutoscalingGroup`, `Eip`, `EBSVolume`, `MachineDeployment` or `RemoteMachine` appears in the diff — the running nodes are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)