### PR TITLE
workers: bound the node drain

### DIFF
--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -903,6 +903,21 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
           spec: {
             clusterName: o.clusterName,
             version: o.k0sVersion.split("+")[0],
+            // Bound the drain. Every node here is its own MachineDeployment of
+            // one, and nothing coordinates them, so a fleet-wide change (a k0s
+            // version bump) drains ALL of them at once. Single-replica
+            // workloads with a PodDisruptionBudget then deadlock permanently:
+            // the pod cannot be evicted until a replacement is healthy, and no
+            // replacement can schedule because every node is cordoned. Observed
+            // live 2026-08-04 on the 1.33 -> 1.34 hop — coredns and
+            // ebs-csi-controller, both pinned to the two system nodes, held
+            // their drains open indefinitely and needed a hand.
+            //
+            // A timeout turns that from a wedge into a bounded outage: the
+            // drain gives up, the machine deletes, the host re-provisions and
+            // comes back schedulable. It does NOT make the roll safe to do
+            // fleet-wide — see the ordering caveat in the runbook.
+            deletion: { nodeDrainTimeoutSeconds: 300 },
             bootstrap: {
               configRef: {
                 apiGroup: "bootstrap.cluster.x-k8s.io",

--- a/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
@@ -225,6 +225,13 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
             spec: {
               clusterName,
               version: workerK8sVersion,
+              // Bound the drain so a PodDisruptionBudget cannot hold a machine
+              // deletion open forever — a single-replica workload has nothing
+              // to fail over to while its node is the one being drained. See
+              // the same field on the AWS worker fleet for the incident.
+              // (v1beta1 spelling here; the fleet emits raw v1beta2, where the
+              // same knob is deletion.nodeDrainTimeoutSeconds.)
+              nodeDrainTimeout: "5m",
               ...(pool.failureDomain ? { failureDomain: pool.failureDomain } : {}),
               bootstrap: {
                 configRef: {


### PR DESCRIPTION
Every fleet node is its own `MachineDeployment` of one and nothing coordinates them, so a fleet-wide change — a k0s version bump — drains **all** of them simultaneously. Single-replica workloads with a PodDisruptionBudget then deadlock permanently: the pod cannot be evicted until a replacement is healthy, and no replacement can schedule because every node is cordoned at once.

Observed live on stage's 1.33 → 1.34 hop:

```
stage-eu-system-1  Drain not completed yet:
  Pod kube-system/coredns-...: cannot evict pod as it would violate the pod's
  disruption budget. The disruption budget coredns needs 1 healthy pods and has 1 currently
stage-eu-system-2  Drain not completed yet:
  Pod kube-system/ebs-csi-controller-...: ... needs 1 healthy pods and has 1 currently
```

Both pods tolerate only the two system nodes (the other seven carry workload taints), and both of those were cordoned. Deleting one blocked pod directly broke the cycle — the freed host re-provisioned, came back schedulable, and the second drain completed on its own — but nothing in the system would have resolved it unattended.

A timeout turns the wedge into a bounded outage: the drain gives up, the machine deletes, the host re-provisions. It does **not** make a fleet-wide roll safe — that needs ordering, which is a separate change.

`deletion.nodeDrainTimeoutSeconds: 300` on the raw v1beta2 fleet MachineDeployments; `nodeDrainTimeout: 5m` on the typed v1beta1 k0smotron pools — same knob, different API version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)