### PR TITLE
k0smotron pools: canonical duration for nodeDrainTimeout

### DIFF
--- a/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
+++ b/packages/nebula/src/modules/infra/k0s/k0smotron-cluster.ts
@@ -230,8 +230,10 @@ export class K0smotronCluster<M> extends BaseConstruct<K0smotronClusterConfig<M>
               // to fail over to while its node is the one being drained. See
               // the same field on the AWS worker fleet for the incident.
               // (v1beta1 spelling here; the fleet emits raw v1beta2, where the
-              // same knob is deletion.nodeDrainTimeoutSeconds.)
-              nodeDrainTimeout: "5m",
+              // same knob is deletion.nodeDrainTimeoutSeconds.) Write the
+              // CANONICAL Go duration: the apiserver stores seconds and renders
+              // them back as "5m0s", so "5m" reads as permanent ArgoCD drift.
+              nodeDrainTimeout: "5m0s",
               ...(pool.failureDomain ? { failureDomain: pool.failureDomain } : {}),
               bootstrap: {
                 configRef: {


### PR DESCRIPTION
`"5m"` is stored as 300 seconds and rendered back as `"5m0s"`, so ArgoCD compared its own manifest against a value it had never written:

```
===== MachineDeployment default/cicd-amd64 ======
178c178
<       nodeDrainTimeout: 5m0s
---
>       nodeDrainTimeout: 5m
```

Both cicd and intra sat permanently OutOfSync on a field that was in fact applied correctly (`deletion.nodeDrainTimeoutSeconds: 300` in the v1beta2 storage form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)