### PR TITLE
calico-wg6-repair: an evicted pod is not a failed run

### DIFF
--- a/packages/nebula/src/modules/k8s/calico-wg6-repair/index.ts
+++ b/packages/nebula/src/modules/k8s/calico-wg6-repair/index.ts
@@ -83,8 +83,25 @@ export class CalicoWg6Repair extends Construct {
         failedJobsHistoryLimit: 3,
         jobTemplate: {
           spec: {
-            backoffLimit: 1,
+            backoffLimit: 3,
             activeDeadlineSeconds: 300,
+            // A pod evicted because its NODE went away is not a failed run.
+            // This job exists to react to node replacement, so it is running
+            // precisely when nodes are being drained — and with backoffLimit 1
+            // a single eviction burned the only retry and the deadline
+            // finished it off. The result was a KubeJobFailed for a job whose
+            // actual work takes three seconds, and because the failed Job is
+            // RETAINED by failedJobsHistoryLimit, kube_job_failed stays > 0 and
+            // the alert never clears on its own. Observed live 2026-08-04: two
+            // spot reclaims produced three permanent alerts.
+            podFailurePolicy: {
+              rules: [
+                {
+                  action: "Ignore",
+                  onPodConditions: [{ type: "DisruptionTarget" }],
+                },
+              ],
+            },
             template: {
               spec: {
                 serviceAccountName: name,


### PR DESCRIPTION
This job exists to react to node replacement, so it runs precisely when nodes are being drained. With `backoffLimit: 1` a single eviction burned the only retry and `activeDeadlineSeconds` finished the job off — for work that takes three seconds.

Worse, the failure is permanent as far as alerting goes: `failedJobsHistoryLimit` **retains** the failed Job, so `kube_job_failed` stays above zero and `KubeJobFailed` never clears without someone deleting the object.

Observed on stage 2026-08-04 — two spot reclaims, three permanently firing alerts:

| job | started | failed | node recreated |
|---|---|---|---|
| `...-29763930` | 09:30 | 09:35 `DeadlineExceeded` | `stage-eu-mainnet-2` 09:36:54 |
| `...-29763945` | 09:45 | 09:50 `DeadlineExceeded` | `stage-eu-mainnet-1` 09:53:26 |

Every surrounding run completed in ~3s, so the logic was never at fault.

`podFailurePolicy` with `action: Ignore` on the `DisruptionTarget` condition is the Kubernetes-native answer — an eviction stops counting against `backoffLimit` entirely (GA since 1.31; the fleet is on 1.35). `backoffLimit` goes to 3 so ordinary retries have room, and the deadline stays so a genuinely hung run still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)