### PR TITLE
CrossplaneProviderSilent: only managed-resource reconcilers

### DIFF
--- a/packages/nebula/src/modules/k8s/crossplane-observability/index.ts
+++ b/packages/nebula/src/modules/k8s/crossplane-observability/index.ts
@@ -253,8 +253,24 @@ export class CrossplaneObservability extends Construct {
                 // an idle provider's burst/gap cycle never reads as silence; a
                 // recent-activity offset guard is wrong here - it drains away
                 // ~1h into a REAL wedge and un-fires the alert.
+                //
+                // Scoped to `managed/` controllers — the MANAGED-RESOURCE
+                // reconcilers — because those are the only ones whose silence
+                // means anything. Counting every controller made this fire on
+                // two providers that are silent BY DESIGN (observed live
+                // 2026-08-04, and once before):
+                //   - upbound-provider-family-aws has NO managed/ controller at
+                //     all, only crd-gate + providerconfig/*. It does its work at
+                //     startup and is then idle forever, but crd-gate alone
+                //     carried it past the lifetime-work floor.
+                //   - provider-aws-kms has managed/ controllers but the estate
+                //     holds zero KMS resources, so they never reconcile; again
+                //     only crd-gate cleared the floor.
+                // With this scope both fall below the floor by construction and
+                // can never fire, while a real reconciler that wedges still
+                // does — provider-aws-ec2 alone carries 510 managed/ reconciles.
                 alert: "CrossplaneProviderSilent",
-                expr: `sum by (pod) (rate(controller_runtime_reconcile_total{namespace="${xns}"}[${window}])) == 0 and on (pod) sum by (pod) (controller_runtime_reconcile_total{namespace="${xns}"}) > ${floor}`,
+                expr: `sum by (pod) (rate(controller_runtime_reconcile_total{namespace="${xns}",controller=~"managed/.*"}[${window}])) == 0 and on (pod) sum by (pod) (controller_runtime_reconcile_total{namespace="${xns}",controller=~"managed/.*"}) > ${floor}`,
                 for: options.silentFor ?? "15m",
                 labels: { severity: "critical" },
                 annotations: {


### PR DESCRIPTION
Counting every controller made this fire on two providers that are silent **by design** — twice now (the first time was triaged as an incident and came back).

- `upbound-provider-family-aws` has **no `managed/` controller at all** — only `crd-gate` and `providerconfig/*`. It does its work at startup and is idle forever after, but `crd-gate`'s 526 lifetime reconciles carried it past the floor that arms the alert.
- `provider-aws-kms` has `managed/` controllers, but the estate holds **zero KMS resources** so they never reconcile. Again only `crd-gate` cleared the floor.

Both are structurally incapable of the failure this alert exists to catch: a managed-resource reconciler that wedges while externals drift. Scoping the expression to `managed/` controllers drops them below the floor **by construction**, rather than via an exclusion list that would rot as providers are added.

Verified against live Prometheus before changing anything:

```
current expr   -> 2 firing: upbound-provider-family-aws-..., provider-aws-kms-...
scoped expr    -> 0 firing

managed/ lifetime totals (rule stays armed for real reconcilers):
  provider-kubernetes  1046      provider-aws-ec2   510
  provider-http         336      provider-aws-iam   198
  provider-aws-kms        0   <- correctly below the floor
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)