### PR TITLE
calico-wg6-repair: bound every kubectl call

### DIFF
--- a/packages/nebula/src/modules/k8s/calico-wg6-repair/index.ts
+++ b/packages/nebula/src/modules/k8s/calico-wg6-repair/index.ts
@@ -29,17 +29,27 @@ export interface CalicoWg6RepairConfig {
   image?: string;
 }
 
+// Every call is bounded. activeDeadlineSeconds is a WALL-CLOCK limit that no
+// podFailurePolicy can exempt, so one hung API call fails the whole Job with
+// DeadlineExceeded — and because failedJobsHistoryLimit retains the object,
+// kube_job_failed stays > 0 and KubeJobFailed never clears on its own.
+// Observed live 2026-08-04: two DeadlineExceeded failures on a job whose real
+// work takes three seconds, while stage's apiserver was returning 504s on
+// leases and node patches. A request timeout turns that into a fast, retried
+// failure instead of a 5-minute stall.
+const KUBECTL = "kubectl --request-timeout=30s";
+
 const SCRIPT = `set -eu
-BAD=$(kubectl get nodes --no-headers -o \\
+BAD=$(${KUBECTL} get nodes --no-headers -o \\
   'custom-columns=N:.metadata.name,W:.metadata.annotations.projectcalico\\.org/IPv6WireguardInterfaceAddr,R:.status.conditions[?(@.type=="Ready")].status' \\
   | awk '$2 == "<none>" && $3 == "True" { print $1 }')
 [ -z "$BAD" ] && { echo "all Ready nodes have a wg6 address"; exit 0; }
 for NODE in $BAD; do
-  POD=$(kubectl get pods -n kube-system -l k8s-app=calico-node \\
+  POD=$(${KUBECTL} get pods -n kube-system -l k8s-app=calico-node \\
     --field-selector "spec.nodeName=$NODE" -o name)
   [ -z "$POD" ] && { echo "no calico-node pod on $NODE yet"; continue; }
   echo "wg6 missing on $NODE — restarting $POD (calico#10599 workaround)"
-  kubectl delete "$POD" -n kube-system --wait=false
+  ${KUBECTL} delete "$POD" -n kube-system --wait=false
 done
 `;
 


### PR DESCRIPTION
The `podFailurePolicy` I added earlier was the wrong fix for the failure actually happening.

It exempts **evicted** pods from the backoff limit. But both failures since it landed were `DeadlineExceeded`, and `activeDeadlineSeconds` is a wall-clock limit that no `podFailurePolicy` can exempt:

```
calico-wg6-repair-29764280  created 15:20  podFailurePolicy present  -> DeadlineExceeded
calico-wg6-repair-29764315  created 15:55  podFailurePolicy present  -> DeadlineExceeded
(policy landed 10:20)
```

For a job whose real work takes ~3s, a 300s overrun means an API call hung — and stage's apiserver was returning 504s on leases and node patches in the same window. Nothing in the script bounded its own calls, so one slow request ate the whole deadline.

`--request-timeout=30s` turns that into a fast failure the backoff retries, instead of a five-minute stall that fails the Job.

This matters beyond noise: `failedJobsHistoryLimit` retains the failed object, so `kube_job_failed` stays above zero and `KubeJobFailed` never clears until someone deletes it by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)