### PR TITLE
capi-operator + descheduler: end BestEffort controllers, rebalance on real usage

### DIFF
--- a/packages/nebula/src/modules/k8s/cluster-api-operator/index.ts
+++ b/packages/nebula/src/modules/k8s/cluster-api-operator/index.ts
@@ -55,6 +55,65 @@ const K0SMOTRON_FETCH_URLS = {
   bootstrap: `${K0SMOTRON_RELEASES_BASE}/bootstrap-components.yaml`,
 };
 
+/**
+ * CAPI core and CAPA both ship `resources: {}` — BestEffort QoS, cpu.shares 2,
+ * the weakest class the kernel has. On a saturated node they lose every CPU
+ * race, and their liveness probe is `/healthz` with the API default
+ * `timeoutSeconds: 1`: three missed seconds thirty seconds apart and the
+ * kubelet kills the process that serves CAPI's CONVERSION WEBHOOK. Everything
+ * that reads a MachineDeployment then fails, which is how a busy node becomes
+ * ArgoCD showing whole clusters `Unknown/Missing` (mgmt, 2026-08-04: 10
+ * restarts in 10h off one node at 114% CPU).
+ *
+ * Requests only, never limits: a CPU limit throttles a controller mid-reconcile
+ * and a memory limit turns a reconcile spike into an OOMKill.
+ */
+const DEFAULT_MANAGER_RESOURCES = {
+  requests: { cpu: "100m", memory: "128Mi" },
+};
+
+/** Probe timeout that survives a loaded node; the API default is 1s. */
+const DEFAULT_PROBE_TIMEOUT_SECONDS = 5;
+
+/** Provider CRs the chart renders; every one of them carries a manager. */
+const PROVIDER_KINDS = new Set([
+  "CoreProvider",
+  "InfrastructureProvider",
+  "BootstrapProvider",
+  "ControlPlaneProvider",
+  "AddonProvider",
+  "IPAMProvider",
+]);
+
+/**
+ * Widen both probes on a provider's manager. The chart templates `deployment`
+ * but not `patches`, so this rides `spec.patches` (strategic merge, targeted by
+ * kind+name) injected onto the rendered provider objects. NOT `manifestPatches`
+ * — that is an RFC 7396 merge patch, and a merge patch on `containers` REPLACES
+ * the list rather than merging into the container of that name.
+ */
+function probeTimeoutPatch(timeoutSeconds: number): Record<string, unknown> {
+  return {
+    // Existence-selector on kubebuilder's `control-plane` label. Every provider
+    // marks its manager Deployment with it (the VALUE differs — CAPA uses
+    // `capa-controller-manager`, CAPI core `controller-manager`) and nothing
+    // else does, so this cannot land on a sidecar Deployment and have the
+    // strategic merge INVENT an imageless container named `manager`.
+    target: { kind: "Deployment", labelSelector: "control-plane" },
+    patch: [
+      "spec:",
+      "  template:",
+      "    spec:",
+      "      containers:",
+      "        - name: manager",
+      "          livenessProbe:",
+      `            timeoutSeconds: ${timeoutSeconds}`,
+      "          readinessProbe:",
+      `            timeoutSeconds: ${timeoutSeconds}`,
+    ].join("\n"),
+  };
+}
+
 /** GCP IAM configuration for CAPG */
 export interface ClusterApiOperatorGcpConfig {
   /** GCP project ID */
@@ -173,6 +232,18 @@ export interface ClusterApiOperatorConfig {
   aws?: ClusterApiOperatorAwsConfig;
   /** Hetzner configuration for CAPH setup */
   hetzner?: ClusterApiOperatorHetznerConfig;
+  /**
+   * Resource requests for every provider's `manager` container, so none of them
+   * runs BestEffort. `false` leaves each provider's shipped resources alone.
+   * @default { requests: { cpu: '100m', memory: '128Mi' } }
+   */
+  managerResources?: { requests?: Record<string, string> } | false;
+  /**
+   * Liveness/readiness `timeoutSeconds` for every provider's manager. `false`
+   * keeps the Kubernetes default of 1s.
+   * @default 5
+   */
+  probeTimeoutSeconds?: number | false;
 }
 
 export class ClusterApiOperator extends HelmModule<ClusterApiOperatorConfig> {
@@ -321,6 +392,25 @@ export class ClusterApiOperator extends HelmModule<ClusterApiOperatorConfig> {
       };
     }
 
+    // Applied last so it reaches EVERY provider, including the GCP entry the
+    // block above rebuilds. `defaultValues.infrastructure` aliases
+    // `infrastructureProviders`, so one walk covers all four provider tiers.
+    const managerResources =
+      this.config.managerResources === false
+        ? undefined
+        : (this.config.managerResources ?? DEFAULT_MANAGER_RESOURCES);
+    if (managerResources) {
+      for (const tier of ["core", "controlPlane", "bootstrap", "infrastructure"]) {
+        for (const provider of Object.values(
+          (defaultValues[tier] ?? {}) as Record<string, Record<string, unknown>>,
+        )) {
+          provider.deployment = {
+            containers: [{ name: "manager", resources: managerResources }],
+          };
+        }
+      }
+    }
+
     this.helm = this.createHelmRelease({
       namespace: namespaceName,
       chart: "cluster-api-operator",
@@ -340,8 +430,13 @@ export class ClusterApiOperator extends HelmModule<ClusterApiOperatorConfig> {
     // so they are never tracked, re-created on sync, or shown in the UI.
     // Stripping the hook annotations converts them into normal ArgoCD-managed
     // resources that survive deletion and get recreated automatically.
+    const probeTimeout =
+      this.config.probeTimeoutSeconds === false
+        ? undefined
+        : (this.config.probeTimeoutSeconds ?? DEFAULT_PROBE_TIMEOUT_SECONDS);
     for (const child of this.helm.apiObjects) {
-      const annotations = child.toJson()?.metadata?.annotations;
+      const json = child.toJson();
+      const annotations = json?.metadata?.annotations;
       if (annotations?.["helm.sh/hook"]) {
         child.addJsonPatch(
           JsonPatch.remove("/metadata/annotations/helm.sh~1hook"),
@@ -350,6 +445,11 @@ export class ClusterApiOperator extends HelmModule<ClusterApiOperatorConfig> {
       if (annotations?.["helm.sh/hook-weight"]) {
         child.addJsonPatch(
           JsonPatch.remove("/metadata/annotations/helm.sh~1hook-weight"),
+        );
+      }
+      if (probeTimeout && PROVIDER_KINDS.has(json?.kind) && json?.spec) {
+        child.addJsonPatch(
+          JsonPatch.add("/spec/patches", [probeTimeoutPatch(probeTimeout)]),
         );
       }
     }

--- a/packages/nebula/src/modules/k8s/descheduler/index.ts
+++ b/packages/nebula/src/modules/k8s/descheduler/index.ts
@@ -55,6 +55,27 @@ export interface DeschedulerConfig {
     memory?: number;
     pods?: number;
   };
+  /**
+   * Drive LowNodeUtilization from ACTUAL usage (metrics-server) instead of pod
+   * requests. Requests are only a proxy for load, and a bad one wherever a
+   * large share of pods run BestEffort: mgmt measured 42/63/25% CPU by request
+   * against 15/37/11% actual, so a request-driven rebalance would chase a
+   * number nothing in the cluster experiences. `pods` is dropped from the
+   * thresholds in this mode — metrics report cpu and memory, not pod counts.
+   * @default false
+   */
+  useActualUsage?: boolean;
+  /**
+   * Never evict a pod with a PersistentVolumeClaim. `nodeFit` does not model
+   * volume topology, so without this the descheduler will happily evict a pod
+   * whose PV pins it to one AZ and get it rescheduled onto the node it just
+   * left — a restart bought for nothing (on mgmt that restart is a child
+   * cluster's etcd).
+   * @default true
+   */
+  ignorePvcPods?: boolean;
+  /** Cap evictions per node per run; bounds the churn of one pass. */
+  maxNoOfPodsToEvictPerNode?: number;
   /** Namespaces to exclude from descheduling */
   excludeNamespaces?: string[];
   /** Priority class name (defaults to system-cluster-critical) */
@@ -154,6 +175,8 @@ export class Descheduler extends HelmModule<DeschedulerConfig> {
       });
     }
 
+    const useActualUsage = this.config.useActualUsage === true;
+
     if (this.config.enableLowNodeUtilization !== false) {
       pluginConfig.push({
         name: "LowNodeUtilization",
@@ -161,13 +184,16 @@ export class Descheduler extends HelmModule<DeschedulerConfig> {
           thresholds: {
             cpu: lowThresholds.cpu,
             memory: lowThresholds.memory,
-            pods: lowThresholds.pods,
+            ...(useActualUsage ? {} : { pods: lowThresholds.pods }),
           },
           targetThresholds: {
             cpu: targetThresholds.cpu,
             memory: targetThresholds.memory,
-            pods: targetThresholds.pods,
+            ...(useActualUsage ? {} : { pods: targetThresholds.pods }),
           },
+          ...(useActualUsage
+            ? { metricsUtilization: { source: "KubernetesMetrics" } }
+            : {}),
           ...evictableNamespaceArgs,
         },
       });
@@ -208,8 +234,15 @@ export class Descheduler extends HelmModule<DeschedulerConfig> {
       });
     }
 
-    // Build descheduler policy
+    // Build descheduler policy. `metricsProviders` is what the chart keys the
+    // metrics.k8s.io RBAC rule off, so it must be set alongside the plugin arg.
     const deschedulerPolicy = {
+      ...(useActualUsage
+        ? { metricsProviders: [{ source: "KubernetesMetrics" }] }
+        : {}),
+      ...(this.config.maxNoOfPodsToEvictPerNode
+        ? { maxNoOfPodsToEvictPerNode: this.config.maxNoOfPodsToEvictPerNode }
+        : {}),
       profiles: [
         {
           name: "default",
@@ -227,22 +260,23 @@ export class Descheduler extends HelmModule<DeschedulerConfig> {
     };
 
     // Prepend a DefaultEvictor (eviction policy). Namespace exclusion itself is
-    // applied per-plugin via the args above, not here.
-    if (excludeNamespaces.length > 0) {
-      (deschedulerPolicy.profiles[0] as Record<string, unknown>).pluginConfig =
-        [
-          {
-            name: "DefaultEvictor",
-            args: {
-              evictSystemCriticalPods: false,
-              evictFailedBarePods: true,
-              evictLocalStoragePods: false,
-              nodeFit: true,
-            },
-          },
-          ...pluginConfig,
-        ];
-    }
+    // applied per-plugin via the args above, not here — which is why this is
+    // unconditional: these guards are what keep the evictor away from critical
+    // and stateful pods, and they must hold whether or not namespaces are
+    // excluded.
+    (deschedulerPolicy.profiles[0] as Record<string, unknown>).pluginConfig = [
+      {
+        name: "DefaultEvictor",
+        args: {
+          evictSystemCriticalPods: false,
+          evictFailedBarePods: true,
+          evictLocalStoragePods: false,
+          ignorePvcPods: this.config.ignorePvcPods !== false,
+          nodeFit: true,
+        },
+      },
+      ...pluginConfig,
+    ];
 
     // Portable by default (no vendor-specific tolerations). Add via config/values
     // where needed (e.g. GKE: components.gke.io/gke-managed-components).


### PR DESCRIPTION
## Why

`capi-controller-manager` and `capa-controller-manager` ship `resources: {}` — BestEffort QoS, `cpu.shares` 2 — and their liveness/readiness probes use the API default `timeoutSeconds: 1`. On a saturated node they lose the CPU race, miss three probes 30s apart, and the kubelet kills the process that serves **CAPI's conversion webhook**. Everything that reads a `MachineDeployment` then fails, which is how a busy node turns into ArgoCD showing whole clusters `Unknown/Missing`.

Measured on mgmt 2026-08-04: 10 restarts in 10h off one node at 114% CPU, taking `cluster-cicd` down with it. 41 of mgmt's 72 pods are BestEffort.

## What

**`ClusterApiOperator`**
- Every provider (core, bootstrap, control-plane, all infrastructure) gets `requests: {cpu: 100m, memory: 128Mi}` through the operator's own `spec.deployment.containers[].resources`. Requests only — a CPU limit throttles a reconcile mid-flight, a memory limit turns a reconcile spike into an OOMKill.
- Both probes get `timeoutSeconds: 5` through `spec.patches`. **Not `manifestPatches`** — that field is RFC 7396, and a merge patch on `containers` replaces the whole list rather than merging into the container of that name. The chart templates `deployment` but not `patches`, so the patch is injected onto the rendered provider CRs in the loop that already strips the helm hook annotations.
- The patch targets kubebuilder's `control-plane` label (existence, since the *value* differs per provider) so a strategic merge can never land on a sidecar Deployment and invent an imageless container named `manager`.
- Both are overridable: `managerResources: false` / `probeTimeoutSeconds: false` leave upstream alone.

**`Descheduler`**
- `useActualUsage` drives `LowNodeUtilization` from metrics-server instead of pod requests, and sets `metricsProviders` (which is what the chart keys the `metrics.k8s.io` RBAC rule off). Requests are a poor proxy for load wherever BestEffort is common: mgmt reads 42/63/25% CPU by request against 15/37/11% actual. `pods` drops out of the thresholds in this mode — metrics carry cpu and memory only.
- `ignorePvcPods` (default **true**). `nodeFit` does not model volume topology, so without it the descheduler evicts a pod whose PV pins it to one AZ and the scheduler puts it straight back on the node it just left. On mgmt that pointless restart is a child cluster's etcd.
- `maxNoOfPodsToEvictPerNode` to bound one pass.
- DefaultEvictor is now emitted unconditionally. It was gated on `excludeNamespaces.length > 0`, but its guards (`evictSystemCriticalPods: false`, `ignorePvcPods`, `nodeFit`) need to hold either way.

## Behaviour change for existing callers

`ignorePvcPods` defaults to true, so **intra's descheduler stops evicting PVC-backed pods** (Thanos, Grafana, Tempo). This matches the upstream chart's own default and is the intended behaviour of a rebalancer; called out because it is a live change, not a no-op.

## Verified

- `tsc --noEmit` clean.
- Synthesized: all five providers carry the resources block and the probe patch; the descheduler policy renders `metricsProviders`, `metricsUtilization: {source: KubernetesMetrics}`, cpu/memory-only thresholds, `ignorePvcPods: true`, and the ClusterRole picks up `metrics.k8s.io`.
- Container name `manager` and the `control-plane` label confirmed on all five live provider Deployments; each provider namespace holds exactly one Deployment.