### PR TITLE
capi-operator: drop the probe-timeout patch, keep the resource requests

### DIFF
--- a/packages/nebula/src/modules/k8s/cluster-api-operator/index.ts
+++ b/packages/nebula/src/modules/k8s/cluster-api-operator/index.ts
@@ -72,47 +72,22 @@ const DEFAULT_MANAGER_RESOURCES = {
   requests: { cpu: "100m", memory: "128Mi" },
 };
 
-/** Probe timeout that survives a loaded node; the API default is 1s. */
-const DEFAULT_PROBE_TIMEOUT_SECONDS = 5;
-
-/** Provider CRs the chart renders; every one of them carries a manager. */
-const PROVIDER_KINDS = new Set([
-  "CoreProvider",
-  "InfrastructureProvider",
-  "BootstrapProvider",
-  "ControlPlaneProvider",
-  "AddonProvider",
-  "IPAMProvider",
-]);
-
 /**
- * Widen both probes on a provider's manager. The chart templates `deployment`
- * but not `patches`, so this rides `spec.patches` (strategic merge, targeted by
- * kind+name) injected onto the rendered provider objects. NOT `manifestPatches`
- * — that is an RFC 7396 merge patch, and a merge patch on `containers` REPLACES
- * the list rather than merging into the container of that name.
+ * The 1s probe timeout stays as upstream ships it. There is NO safe way to
+ * widen it from here, which is worth stating so nobody re-derives the idea:
+ * `ContainerSpec` carries no probe fields, and both patch mechanisms merge
+ * rather than strategic-merge, so a patch naming only `livenessProbe` REPLACES
+ * `containers[0]` with a container that has neither an image nor a probe
+ * handler. Tried live 2026-08-04 via `spec.patches`; the operator retried ten
+ * times and gave up:
+ *
+ *   Deployment "capi-controller-manager" is invalid:
+ *     spec.template.spec.containers[0].image: Required value,
+ *     spec.template.spec.containers[0].livenessProbe: must specify a handler type
+ *
+ * The requests above are the fix that matters — Burstable is what wins the CPU
+ * race that made a 1s timeout reachable in the first place.
  */
-function probeTimeoutPatch(timeoutSeconds: number): Record<string, unknown> {
-  return {
-    // Existence-selector on kubebuilder's `control-plane` label. Every provider
-    // marks its manager Deployment with it (the VALUE differs — CAPA uses
-    // `capa-controller-manager`, CAPI core `controller-manager`) and nothing
-    // else does, so this cannot land on a sidecar Deployment and have the
-    // strategic merge INVENT an imageless container named `manager`.
-    target: { kind: "Deployment", labelSelector: "control-plane" },
-    patch: [
-      "spec:",
-      "  template:",
-      "    spec:",
-      "      containers:",
-      "        - name: manager",
-      "          livenessProbe:",
-      `            timeoutSeconds: ${timeoutSeconds}`,
-      "          readinessProbe:",
-      `            timeoutSeconds: ${timeoutSeconds}`,
-    ].join("\n"),
-  };
-}
 
 /** GCP IAM configuration for CAPG */
 export interface ClusterApiOperatorGcpConfig {
@@ -238,12 +213,6 @@ export interface ClusterApiOperatorConfig {
    * @default { requests: { cpu: '100m', memory: '128Mi' } }
    */
   managerResources?: { requests?: Record<string, string> } | false;
-  /**
-   * Liveness/readiness `timeoutSeconds` for every provider's manager. `false`
-   * keeps the Kubernetes default of 1s.
-   * @default 5
-   */
-  probeTimeoutSeconds?: number | false;
 }
 
 export class ClusterApiOperator extends HelmModule<ClusterApiOperatorConfig> {
@@ -430,13 +399,8 @@ export class ClusterApiOperator extends HelmModule<ClusterApiOperatorConfig> {
     // so they are never tracked, re-created on sync, or shown in the UI.
     // Stripping the hook annotations converts them into normal ArgoCD-managed
     // resources that survive deletion and get recreated automatically.
-    const probeTimeout =
-      this.config.probeTimeoutSeconds === false
-        ? undefined
-        : (this.config.probeTimeoutSeconds ?? DEFAULT_PROBE_TIMEOUT_SECONDS);
     for (const child of this.helm.apiObjects) {
-      const json = child.toJson();
-      const annotations = json?.metadata?.annotations;
+      const annotations = child.toJson()?.metadata?.annotations;
       if (annotations?.["helm.sh/hook"]) {
         child.addJsonPatch(
           JsonPatch.remove("/metadata/annotations/helm.sh~1hook"),
@@ -445,11 +409,6 @@ export class ClusterApiOperator extends HelmModule<ClusterApiOperatorConfig> {
       if (annotations?.["helm.sh/hook-weight"]) {
         child.addJsonPatch(
           JsonPatch.remove("/metadata/annotations/helm.sh~1hook-weight"),
-        );
-      }
-      if (probeTimeout && PROVIDER_KINDS.has(json?.kind) && json?.spec) {
-        child.addJsonPatch(
-          JsonPatch.add("/spec/patches", [probeTimeoutPatch(probeTimeout)]),
         );
       }
     }


### PR DESCRIPTION
Backs out the `spec.patches` half of #114. It does not work, and it blocked the half that does.

Applied live on mgmt, the operator retried ten times and gave up:

```
Deployment.apps "capi-controller-manager" is invalid:
  spec.template.spec.containers[0].image: Required value,
  spec.template.spec.containers[0].livenessProbe: Required value: must specify a handler type,
  spec.template.spec.containers[0].readinessProbe: Required value: must specify a handler type
```

Despite the CRD describing `patches` as supporting strategic merge, the operator merged it — replacing `containers[0]` with a container that has only the two probe stubs. The `control-plane` label selector was correct and irrelevant; the problem is the merge semantics, not the targeting.

Because the patch is part of the same apply, **the resource requests did not land either** — the provider CRs took the new spec (generation 2) but `ProviderInstalled` stayed at observedGeneration 1 and the Deployments kept their old spec. The failure mode was safe: all five managers stayed `1/1 Running` throughout.

`ContainerSpec` (`spec.deployment.containers[]`) carries `args`, `command`, `env`, `image`, `name` and `resources` — no probe fields — so there is no supported path to the timeout at all. The comment left in place records that so the idea isn't re-derived from the same reasoning.

Requests via `spec.deployment` are untouched and are the fix that matters: Burstable QoS is what wins the CPU race that made a 1s timeout reachable to begin with.