### PR TITLE
MemberMonitoring: disable the control-plane component scrapes by default

### DIFF
--- a/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/member-monitoring.ts
@@ -130,6 +130,19 @@ export class MemberMonitoring extends BaseConstruct<MemberMonitoringConfig> {
       grafana: { enabled: false },
       alertmanager: { enabled: false },
 
+      // No cluster we build exposes a scrapeable controller-manager or
+      // scheduler: k0s runs both in-process bound to localhost, and a hosted-CP
+      // child runs them as k0smotron pods on the PARENT. The chart's
+      // ServiceMonitors select nothing and its KubeControllerManagerDown /
+      // KubeSchedulerDown rules then fire forever — two permanent CRITICALs per
+      // spoke (cicd from 2026-08-03, stage from 2026-07-29, unnoticed because a
+      // spoke's local alerts route nowhere). mgmt and the intra hub each set
+      // this by hand after rediscovering it; make it the default instead.
+      // kubeEtcd is NOT included: mgmt runs a real etcd, so that one is a
+      // per-cluster call.
+      kubeControllerManager: { enabled: false },
+      kubeScheduler: { enabled: false },
+
       // Admission webhook + TLS fully off (see the header for why all three
       // switches are required).
       prometheusOperator: {


### PR DESCRIPTION
No cluster we build exposes a scrapeable `kube-controller-manager` or `kube-scheduler`: k0s runs both in-process bound to localhost, and a hosted-CP child runs them as k0smotron pods on the **parent**. The chart's ServiceMonitors select nothing, and its `KubeControllerManagerDown` / `KubeSchedulerDown` rules fire permanently.

Found while sweeping estate alerts — **two permanent CRITICALs on each of cicd and stage**:

| cluster | firing since |
|---|---|
| cicd | 2026-08-03T23:12Z |
| stage | 2026-07-29T23:08Z |

Nobody saw them because a spoke's local alerts route nowhere by design (hub-evaluated rules are canonical, and the hub does not carry these rules at all since intra disables the components).

mgmt (`clusters/mgmt/monitoring/index.ts`) and the intra hub (`clusters/intra/monitoring/index.ts`) had each already set this by hand after hitting it independently — that duplication is the signal it belongs in the preset rather than in every consumer.

`kubeEtcd` deliberately stays out: mgmt runs a real etcd, so it is a per-cluster call. cicd and stage get it explicitly on the DevOps side.

Callers can still override — `deepmerge(memberValues, this.config.values)` puts user values last.

Verified: `tsc --noEmit` clean; confirmed live that cicd, stage **and** intra all have zero `kube-controller-manager`/`kube-scheduler` pods, and that cicd/stage carry the dead ServiceMonitors while intra and mgmt do not.