### PR TITLE
Cilium: a first-class CNI module, and CNI-aware node security groups

### DIFF
--- a/packages/nebula/src/modules/infra/aws/index.ts
+++ b/packages/nebula/src/modules/infra/aws/index.ts
@@ -165,5 +165,6 @@ export type {
   AwsWorkerFleetRegion,
   AwsWorkerFleetNode,
   AwsWorkerFleetPort,
+  AwsWorkerFleetCni,
 } from "./worker-fleet";
 export type { DualStackSubnetConfig } from "./dualstack-subnet";

--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -38,6 +38,7 @@ import { Worker } from "../k0s/worker";
 import { DualStackSubnet } from "./dualstack-subnet";
 import { resolveSecrets } from "../../../utils/secrets";
 import { syncWave } from "../../../core";
+import { CILIUM_WIREGUARD_PORT } from "../../k8s/cilium";
 import {
   OWNED_POLICIES,
   asPolicies,
@@ -65,6 +66,9 @@ export interface AwsWorkerFleetPort {
   port: number;
   protocol: string;
   description: string;
+  /** Emit only the ::/0 rule — for listeners that bind a single family, such
+   *  as Calico's separate v6 WireGuard socket. */
+  v6Only?: boolean;
 }
 
 export interface AwsWorkerFleetOptions {
@@ -115,9 +119,24 @@ export interface AwsWorkerFleetOptions {
    * Calico silently fall back to CLEARTEXT over the internet for any peer
    * whose WireGuard is broken. No plaintext exporters (9100/10249): scraped
    * over the WireGuard mesh instead.
+   *
+   * The CNI's own WireGuard ports are NOT part of this list — see
+   * {@link AwsWorkerFleetOptions.cni}.
    */
   openPorts?: AwsWorkerFleetPort[];
+  /**
+   * Which CNI holds the mesh, so the node security group opens ITS WireGuard
+   * ports. Default "calico" — the port sets do not overlap, and pointing this
+   * at the wrong one is a silent 100% cross-node loss.
+   *
+   * This does not install anything. It must agree with the cluster's
+   * `networkProvider` ("calico" for the k0s-bundled CNI, "custom" plus the
+   * Cilium module for "cilium").
+   */
+  cni?: AwsWorkerFleetCni;
 }
+
+export type AwsWorkerFleetCni = "calico" | "cilium";
 
 export interface AwsWorkerFleetRegion {
   /** Short geo tag, e.g. "eu" — used in resource names and node labels. */
@@ -197,10 +216,37 @@ export interface AwsWorkerFleetNode {
 }
 
 const DEFAULT_OPEN_PORTS: AwsWorkerFleetPort[] = [
-  { port: 51820, protocol: "udp", description: "calico WireGuard (Noise-authenticated)" },
   { port: 10250, protocol: "tcp", description: "kubelet (TLS, authn/authz)" },
   { port: 22, protocol: "tcp", description: "sshd (key-only; RemoteMachine provisioning)" },
 ];
+
+/**
+ * The mesh transport, appended to `openPorts` rather than part of it — a
+ * caller overriding the node ports must not be able to close the CNI's own
+ * tunnel out from under itself.
+ *
+ * Getting this wrong is SILENT: the WireGuard interface comes up, peers are
+ * configured, and every handshake is dropped with nothing in any log. Cilium
+ * listens on one port for both families; Calico runs a separate v6 socket.
+ */
+const CNI_MESH_PORTS: Record<AwsWorkerFleetCni, AwsWorkerFleetPort[]> = {
+  calico: [
+    { port: 51820, protocol: "udp", description: "calico WireGuard (Noise-authenticated)" },
+    {
+      port: 51821,
+      protocol: "udp",
+      description: "calico WireGuard v6 (Noise-authenticated)",
+      v6Only: true,
+    },
+  ],
+  cilium: [
+    {
+      port: CILIUM_WIREGUARD_PORT,
+      protocol: "udp",
+      description: "cilium WireGuard (Noise-authenticated)",
+    },
+  ],
+};
 
 /**
  * The fleet: shared options + emitters for IAM, EIPs, region networks and
@@ -465,7 +511,7 @@ export class AwsWorkerFleet extends Construct {
     const rules = [
       ...(this.options.openPorts ?? DEFAULT_OPEN_PORTS),
       ...(cfg.extraOpenPorts ?? []),
-      { port: 51821, protocol: "udp", description: "calico WireGuard v6 (Noise-authenticated)" },
+      ...CNI_MESH_PORTS[this.options.cni ?? "calico"],
     ];
     rules.forEach((r) => {
       (
@@ -474,7 +520,7 @@ export class AwsWorkerFleet extends Construct {
           ["any6", { cidrIpv6: "::/0" }],
         ] as const
       ).forEach(([suffix, cidr]) => {
-        if (r.port === 51821 && suffix === "any") return;
+        if (r.v6Only && suffix === "any") return;
         const n = `${p}-in-${r.protocol}-${r.port}-${suffix}`;
         new ApiObject(this, n, {
           apiVersion: "ec2.aws.upbound.io/v1beta1",

--- a/packages/nebula/src/modules/k8s/cilium/index.ts
+++ b/packages/nebula/src/modules/k8s/cilium/index.ts
@@ -7,7 +7,7 @@
  * the mesh, and reconciles it with an edge-triggered loop that has no periodic
  * resync (absent in release-v3.31 and master alike). A missed allocation is
  * permanent until calico-node restarts, which is the entire reason the
- * `calico-wg6-repair` janitor exists. Cilium has no equivalent concept: the
+ * `calico-wg-repair` janitor exists. Cilium has no equivalent concept: the
  * node IP is the endpoint, the pod CIDRs are the AllowedIPs, and CiliumNode
  * carries a public KEY rather than an allocation — verified on a real
  * cross-region cluster, including through an unattended spot reclaim.

--- a/packages/nebula/src/modules/k8s/cilium/index.ts
+++ b/packages/nebula/src/modules/k8s/cilium/index.ts
@@ -1,0 +1,163 @@
+/**
+ * Cilium — CNI with WireGuard encryption, for clusters whose k0s installs no
+ * CNI itself (`networkProvider: "custom"`).
+ *
+ * WHY THIS EXISTS ALONGSIDE THE BUNDLED CALICO. Calico's WireGuard needs an
+ * IPAM-allocated tunnel address per node PER FAMILY before that node can join
+ * the mesh, and reconciles it with an edge-triggered loop that has no periodic
+ * resync (absent in release-v3.31 and master alike). A missed allocation is
+ * permanent until calico-node restarts, which is the entire reason the
+ * `calico-wg6-repair` janitor exists. Cilium has no equivalent concept: the
+ * node IP is the endpoint, the pod CIDRs are the AllowedIPs, and CiliumNode
+ * carries a public KEY rather than an allocation — verified on a real
+ * cross-region cluster, including through an unattended spot reclaim.
+ *
+ * The CNI is immutable after cluster creation, so adopting this is a cluster
+ * REBUILD, never an in-place conversion.
+ *
+ * The agent is hostNetwork, so it bootstraps onto NotReady nodes with no CNI
+ * present — no chicken-and-egg to sequence around.
+ *
+ * @example
+ * ```typescript
+ * new Cilium(chart, "cilium", {
+ *   ipv6: true,
+ *   underlayProtocol: "ipv6", // mandatory cross-region
+ *   mtu: 1400,                // the internet path, not the local NIC
+ * });
+ * ```
+ */
+import { Construct } from "constructs";
+import { Helm } from "cdk8s";
+import { HelmModule } from "../../../core";
+
+/**
+ * Cilium's WireGuard UDP port — NOT Calico's 51820. A security group that
+ * opens the Calico port instead fails silently: the interface comes up, peers
+ * are configured, and every handshake is dropped with nothing in the logs.
+ */
+export const CILIUM_WIREGUARD_PORT = 51871;
+
+/**
+ * IPv6's minimum link MTU (RFC 8200). Linux strips IPv6 from any interface
+ * below it — see the fail-closed check in the constructor for why that is a
+ * one-way door here rather than a warning.
+ */
+export const IPV6_MIN_MTU = 1280;
+
+export interface CiliumConfig {
+  /** Namespace (defaults to kube-system, which is never created here). */
+  namespace?: string;
+  /** Helm chart version (defaults to 1.20.0 — the version validated live). */
+  version?: string;
+  /** Helm repository URL. */
+  repository?: string;
+  /** Dual-stack. Requires the cluster's k0s config to allocate v6 podCIDRs. */
+  ipv6?: boolean;
+  /**
+   * Tunnel MTU, applied to every interface Cilium owns.
+   *
+   * LEAVING THIS UNSET IS WRONG ON ANY INTERNET-CROSSING MESH. Cilium derives
+   * the WireGuard MTU from the local NIC exactly as Calico does — on a 9001
+   * jumbo host `cilium_wg0` lands at 8906, sized for a path that does not
+   * exist between regions. Set it from the worst path (1400 for a ~1500
+   * internet hop), not from what `ip link` reports.
+   */
+  mtu?: number;
+  /**
+   * Which family carries the tunnel between nodes.
+   *
+   * "ipv6" is MANDATORY on a cross-region fleet: private v4 has no inter-region
+   * path and the AWS IPv6 GUA is on-link, making it the only mutually
+   * reachable node identity. The chart's "auto" picks v4 and the mesh then
+   * never forms — silently, since each node believes its own config.
+   */
+  underlayProtocol?: "auto" | "ipv4" | "ipv6";
+  /** Encapsulation (defaults to vxlan). */
+  tunnelProtocol?: "vxlan" | "geneve";
+  /** WireGuard pod-to-pod encryption (defaults to true). */
+  encryption?: boolean;
+  /**
+   * Also encrypt host-network traffic (defaults to false). Still beta
+   * upstream; pod-to-pod is the GA path.
+   */
+  nodeEncryption?: boolean;
+  /**
+   * Replace kube-proxy (defaults to false — keep k0s's). Enabling it needs
+   * k0s told to skip kube-proxy, which is a separate cluster-spec change.
+   */
+  kubeProxyReplacement?: boolean;
+  /** Operator replicas (defaults to 2; use 1 on a one- or two-node cluster,
+   *  where the default sits Pending under its own anti-affinity whenever a
+   *  node is being replaced). */
+  operatorReplicas?: number;
+  /** Additional Helm values, deep-merged over the defaults above. */
+  values?: Record<string, unknown>;
+}
+
+export class Cilium extends HelmModule<CiliumConfig> {
+  public readonly helm: Helm;
+
+  constructor(scope: Construct, id: string, config: CiliumConfig = {}) {
+    super(scope, id, config);
+
+    const namespace = this.config.namespace ?? "kube-system";
+    const ipv6 = this.config.ipv6 ?? false;
+    const mtu = this.config.mtu;
+
+    // Fail closed on a sub-1280 MTU. This is not a preference: Linux removes
+    // IPv6 from any interface below the v6 minimum, so the kernel strips it
+    // from `cilium_host` and the agent then dies on the missing
+    // /proc/sys/net/ipv6/conf/cilium_host/forwarding BEFORE reaching the code
+    // that would resize the device. `cilium_host` outlives the pod, so
+    // correcting this value does NOT recover the node — the device has to be
+    // deleted or the host rebooted. Observed on every agent at mtu 1200.
+    if (mtu !== undefined && mtu < IPV6_MIN_MTU) {
+      throw new Error(
+        `Cilium: mtu ${mtu} is below the IPv6 minimum of ${IPV6_MIN_MTU}. ` +
+          "Linux would strip IPv6 from cilium_host and crash-loop every " +
+          "agent, and the host device outlives the pod so reverting this " +
+          "value does not recover the node.",
+      );
+    }
+
+    this.helm = this.createHelmRelease({
+      namespace,
+      chart: "cilium",
+      releaseName: "cilium",
+      repo: this.config.repository ?? "https://helm.cilium.io",
+      version: this.config.version ?? "1.20.0",
+      defaultValues: {
+        // Consume the podCIDRs k0s already allocates per node rather than
+        // letting Cilium carve an independent pool the cluster disagrees with.
+        ipam: { mode: "kubernetes" },
+        ipv4: { enabled: true },
+        ipv6: { enabled: ipv6 },
+
+        // Pod CIDRs are not natively routable between regions, so encapsulate.
+        routingMode: "tunnel",
+        tunnelProtocol: this.config.tunnelProtocol ?? "vxlan",
+        ...(this.config.underlayProtocol
+          ? { underlayProtocol: this.config.underlayProtocol }
+          : {}),
+
+        encryption: {
+          enabled: this.config.encryption ?? true,
+          type: "wireguard",
+          nodeEncryption: this.config.nodeEncryption ?? false,
+        },
+
+        // Helm wants the string, not the boolean.
+        kubeProxyReplacement: this.config.kubeProxyReplacement
+          ? "true"
+          : "false",
+
+        ...(mtu ? { MTU: mtu } : {}),
+        ...(this.config.operatorReplicas
+          ? { operator: { replicas: this.config.operatorReplicas } }
+          : {}),
+      },
+      values: this.config.values,
+    });
+  }
+}

--- a/packages/nebula/src/modules/k8s/index.ts
+++ b/packages/nebula/src/modules/k8s/index.ts
@@ -263,6 +263,8 @@ export { ImagePullSecret } from "./image-pull-secret";
 export type { ImagePullSecretConfig } from "./image-pull-secret";
 
 export { Calico } from "./calico";
+export { Cilium, CILIUM_WIREGUARD_PORT, IPV6_MIN_MTU } from "./cilium";
+export type { CiliumConfig } from "./cilium";
 export { CorednsV6Face } from "./coredns-v6-face";
 export type { CorednsV6FaceOptions } from "./coredns-v6-face";
 export {


### PR DESCRIPTION
Groundwork for the Calico→Cilium migration. **Installs nothing and changes no existing render**: `networkProvider` still defaults to `"calico"`, and a worker fleet that does not set `cni` emits the same seven security-group rules it did before — verified by synth, since the rule MRs are named from protocol/port, so reordering them inside the list is identity-preserving.

```
--- calico (unchanged) ---     --- cilium ---
t-eu-in-tcp-10250-any          t-eu-in-tcp-10250-any
t-eu-in-tcp-10250-any6         t-eu-in-tcp-10250-any6
t-eu-in-tcp-22-any             t-eu-in-tcp-22-any
t-eu-in-tcp-22-any6            t-eu-in-tcp-22-any6
t-eu-in-udp-51820-any          t-eu-in-udp-51871-any
t-eu-in-udp-51820-any6         t-eu-in-udp-51871-any6
t-eu-in-udp-51821-any6
```

## Why

Calico's WireGuard needs an IPAM-allocated tunnel address per node **per family** before that node can join the mesh, reconciled by an edge-triggered loop with **no periodic resync** — absent in `release-v3.31` and in `master`. A missed allocation is permanent until calico-node restarts, which is the only reason `calico-wg6-repair` exists.

Cilium has no such concept: the node IP is the endpoint, the pod CIDRs are the AllowedIPs, and `CiliumNode` carries a public *key* rather than an allocation. Measured on a real two-region cluster (us-east-1 + ap-northeast-1), through an unattended spot reclaim: zero wireguard annotations before or after, mesh re-formed by itself, 0% cross-region loss on both families.

## The two traps this encodes

**MTU is fail-closed below 1280.** Linux strips IPv6 from any sub-minimum interface, so the kernel removes it from `cilium_host` and the agent dies on the missing `forwarding` sysctl *before* reaching the code that would resize the device. `cilium_host` outlives the pod, so reverting the value does **not** recover the node — it has to be deleted or the host rebooted. A synth-time error is much cheaper.

**Cilium's WireGuard port is 51871, not 51820.** Opening the wrong one fails silently: interface up, peers configured, every handshake dropped, nothing in any log. Hence `cni` on the worker fleet rather than asking each caller to remember a port number.

The CNI mesh ports also move out of `openPorts` and behind that switch, so a caller overriding the node ports can no longer close the mesh out from under itself. The 51821-has-no-v4-rule special case becomes a `v6Only` flag on the port, which is what it always meant.

## Verification

- `tsc --noEmit` clean.
- Rendered `cilium-config` carries every intended value: `mtu: "1400"`, `enable-ipv6: "true"`, `routing-mode: tunnel`, `tunnel-protocol: vxlan`, `underlay-protocol: ipv6`, `enable-wireguard: "true"`, `ipam: kubernetes`, `kube-proxy-replacement: "false"`.
- `mtu: 1200` throws at synth with the reason.
- SG rule names diffed per CNI (table above).