### PR TITLE
mergeKsmValues: stop the second ksm fragment eating the first

### DIFF
--- a/packages/nebula/src/utils/index.ts
+++ b/packages/nebula/src/utils/index.ts
@@ -10,3 +10,4 @@ export {
   dataVolumePolicies,
   asPolicies,
 } from './crossplane-policies';
+export { mergeKsmValues } from './ksm';

--- a/packages/nebula/src/utils/ksm.ts
+++ b/packages/nebula/src/utils/ksm.ts
@@ -1,0 +1,29 @@
+/**
+ * Combining kube-state-metrics values fragments.
+ *
+ * Several modules contribute `customResourceState` config to the SAME
+ * kube-prometheus-stack release — `kubeStateMetricsValues()` for the Crossplane
+ * MR estate, `calicoWireguardKsmValues()` for the per-node WireGuard addresses,
+ * and whatever comes next. They all write
+ * `customResourceState.config.spec.resources`, which makes the obvious
+ * `{ ...a, ...b }` a silent data-loss bug: the shallow spread replaces the
+ * whole `"kube-state-metrics"` key and the earlier fragment's metrics simply
+ * stop existing, with nothing failing and no diff to notice.
+ */
+import { deepmerge } from "deepmerge-ts";
+
+/**
+ * Deep-merge kube-state-metrics values fragments, CONCATENATING the resource
+ * arrays so every contributor's metrics survive.
+ *
+ * @example
+ * ```typescript
+ * values: mergeKsmValues(
+ *   kubeStateMetricsValues(CROSSPLANE_KINDS),
+ *   calicoWireguardKsmValues(),
+ * ),
+ * ```
+ */
+export function mergeKsmValues(...fragments: object[]): object {
+  return fragments.reduce((acc, f) => deepmerge(acc, f), {} as object);
+}


### PR DESCRIPTION
mgmt's monitoring does `values: { ...kubeStateMetricsValues(KINDS) }`. That shallow spread was fine while exactly one module contributed ksm config; adding a second (`calicoWireguardKsmValues`) makes it **silent data loss** — the whole `"kube-state-metrics"` key is replaced, the earlier fragment's metrics stop existing, nothing fails, and there is no diff to notice because the values block still looks right.

Both fragments write `customResourceState.config.spec.resources`, so combining them has to CONCATENATE that array. deepmerge-ts already does; this just gives callers something obvious to reach for instead of a spread.

Verified — merging the crossplane and calico fragments:

```
resources: 2 -> Instance:crossplane_condition/crossplane_external_name/... | Node:calico_wireguard_addr
rbac extraRules preserved: {"extraRules":[{"apiGroups":["ec2.aws.upbound.io"],...}]}
```