### PR TITLE
mergeKsmValues: return Record<string, unknown>

### DIFF
--- a/packages/nebula/src/utils/ksm.ts
+++ b/packages/nebula/src/utils/ksm.ts
@@ -24,6 +24,13 @@ import { deepmerge } from "deepmerge-ts";
  * ),
  * ```
  */
-export function mergeKsmValues(...fragments: object[]): object {
-  return fragments.reduce((acc, f) => deepmerge(acc, f), {} as object);
+export function mergeKsmValues(
+  ...fragments: object[]
+): Record<string, unknown> {
+  // Record<string, unknown>, not object: every consumer of this (a module's
+  // `values`) is typed that way, and `object` does not satisfy it.
+  return fragments.reduce(
+    (acc, f) => deepmerge(acc, f),
+    {} as Record<string, unknown>,
+  ) as Record<string, unknown>;
 }


### PR DESCRIPTION
Every consumer is a module's `values` field, typed `Record<string, unknown>`. `object` does not satisfy it, so the helper as shipped could not be passed anywhere it was meant to go — caught by the DevOps repin.