### PR TITLE
ArgoCdAppTier: let a tier turn CreateNamespace off

### DIFF
--- a/packages/nebula/src/modules/k8s/argocd/app-tier.ts
+++ b/packages/nebula/src/modules/k8s/argocd/app-tier.ts
@@ -153,6 +153,21 @@ export interface ArgoCdAppTierSyncPolicyOverrides {
   prune?: boolean;
   /** Include the `Delete=false` sync option (removing/cascading the Application cannot delete its resources). */
   deleteProtection?: boolean;
+  /**
+   * Emit `CreateNamespace=true` (default true).
+   *
+   * Set FALSE for an app that creates no namespace of its own and whose
+   * resources all land in namespaces that already exist — a CNI, for
+   * instance, which is cluster-scoped plus kube-system.
+   *
+   * This is not cosmetic. ArgoCD v3.3.0 PANICS mid-sync on such an app
+   * ("Recovered from panic: runtime error: invalid memory address or nil
+   * pointer dereference" at controller/sync.go:311, from getSyncTasks),
+   * leaving it at OperationState Error with NOTHING applied and retrying
+   * forever. Syncing the identical manifests with CreateNamespace=false
+   * succeeds immediately. Observed installing Cilium on two clusters.
+   */
+  createNamespace?: boolean;
 }
 
 export interface ArgoCdAppTierPluginConfig {
@@ -693,13 +708,14 @@ export class ArgoCdAppTier extends BaseConstruct<ArgoCdAppTierConfig> {
     const prune = overrides?.prune ?? defaults.prune;
     const deleteProtection =
       overrides?.deleteProtection ?? defaults.deleteProtection;
+    const createNamespace = overrides?.createNamespace ?? true;
 
     return {
       // NEVER render `prune: false` — see the phantom-diff note on the class.
       automated: prune ? { selfHeal: true, prune: true } : { selfHeal: true },
       retry: this.retry,
       syncOptions: [
-        "CreateNamespace=true",
+        `CreateNamespace=${createNamespace}`,
         "ServerSideApply=true",
         "SkipDryRunOnMissingResource=true",
         "RespectIgnoreDifferences=true",


### PR DESCRIPTION
ArgoCD v3.3.0 **panics mid-sync** on an application that creates no namespace of its own and whose resources all land in namespaces that already exist:

```
Recovered from panic: runtime error: invalid memory address or nil pointer dereference
  controller.(*appStateManager).SyncAppState.func1  controller/sync.go:311
  gitops-engine/pkg/sync.(*syncContext).getSyncTasks  sync_context.go:904
```

The app is left at `OperationState: Error` with **nothing applied**, retrying forever. Syncing the identical manifests with `CreateNamespace=false` succeeds immediately.

### This corrects the explanation in #122

That PR claimed the trigger was "the manifests introduce a namespace which does not exist yet". **That was wrong.** `intra-cilium` rendered zero Namespace objects — 17 resources, identical in shape to cicd's — and panicked anyway. The real trigger is `CreateNamespace=true` on an app with an **empty destination namespace** and nothing to create.

The Hubble/Envoy trimming in #122 is still worth keeping on its own merits (the cert regeneration is real and independently verified), but its stated justification for the namespace change was not the cause.

Note this option was doing no useful work for these apps in the first place: with an empty destination namespace there is no namespace for ArgoCD to create.

Default stays `true`, so no existing render changes.