### PR TITLE
AwsK0sProvider: make the IMDSv2 hop limit configurable — Cilium needs 3

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -522,6 +522,20 @@ export function emitAwsMachineTemplate(
      * instance role to every pod. See the field comment below.
      */
     imdsPodAccess?: boolean;
+    /**
+     * IMDSv2 `httpPutResponseHopLimit` when `imdsPodAccess` is on (default 2).
+     *
+     * The token PUT response is TTL-limited, so the limit must cover every hop
+     * between the requester and IMDS. 2 covers a pod one veth away, which is
+     * what Calico gives. **CILIUM NEEDS 3** — its datapath adds a hop, and at 2
+     * the symptom is brutal to read: a plain GET still returns 401 (so IMDS
+     * looks reachable), hostNetwork pods work fine, and only ordinary pods fail
+     * — with `no EC2 IMDS role found` from the AWS SDK, which reads like an IAM
+     * problem rather than a network one. Observed on intra: ebs-csi-controller
+     * and aws-load-balancer-controller both CrashLoopBackOff after the CNI
+     * switch, with volume attach/detach dead cluster-wide.
+     */
+    imdsHopLimit?: number;
   },
 ): AwsMachineTemplateV1Beta2 {
   return new AwsMachineTemplateV1Beta2(scope, id, {
@@ -557,7 +571,7 @@ export function emitAwsMachineTemplate(
                 instanceMetadataOptions: {
                   httpEndpoint: ImdsHttpEndpoint.ENABLED,
                   httpTokens: ImdsHttpTokens.REQUIRED,
-                  httpPutResponseHopLimit: 2,
+                  httpPutResponseHopLimit: opts.imdsHopLimit ?? 2,
                 },
               }
             : {}),

--- a/packages/nebula/src/modules/infra/aws/k0s-provider.ts
+++ b/packages/nebula/src/modules/infra/aws/k0s-provider.ts
@@ -90,6 +90,12 @@ export interface AwsK0sProviderConfig {
    * Applies to control-plane nodes only; workers never expose their role to pods.
    */
   imdsPodAccess?: boolean;
+  /**
+   * IMDSv2 `httpPutResponseHopLimit` for every machine template this provider
+   * renders that has `imdsPodAccess` on (default 2). **Cilium needs 3.**
+   * See the option of the same name in `_shared.ts` for the failure signature.
+   */
+  imdsHopLimit?: number;
 }
 
 /**
@@ -194,6 +200,12 @@ export class AwsK0sProvider implements K0sInfraProvider<AwsMachineSpec> {
           // Only present when opted in, so existing pools' hashes (and thus
           // their machine templates) stay stable.
           ...(imdsPodAccess ? { imdsPodAccess: true } : {}),
+          // MUST be in the hash: AWSMachineTemplate specs are immutable, so a
+          // hop-limit change that does not rename the template is silently
+          // never applied. Omitted at the default for hash stability.
+          ...(imdsPodAccess && this.config.imdsHopLimit
+            ? { imdsHopLimit: this.config.imdsHopLimit }
+            : {}),
         };
     const hash = crypto
       .createHash("sha256")
@@ -213,6 +225,7 @@ export class AwsK0sProvider implements K0sInfraProvider<AwsMachineSpec> {
       rootVolumeType,
       ami: m.ami,
       ...(imdsPodAccess !== undefined ? { imdsPodAccess } : {}),
+      ...(this.config.imdsHopLimit ? { imdsHopLimit: this.config.imdsHopLimit } : {}),
       ...(spot !== undefined ? { spot } : {}),
     });
 


### PR DESCRIPTION
The keyless model breaks the moment a cluster moves to Cilium. The IMDSv2 token PUT response is TTL-limited, so the hop limit must cover every hop between requester and IMDS. 2 covers a pod one veth away, which is what Calico gives; **Cilium's datapath adds a hop**, and at 2 every pod-networked AWS controller loses its credentials.

Observed on intra immediately after the CNI switch: `ebs-csi-controller` and `aws-load-balancer-controller` both CrashLoopBackOff — meaning **volume attach/detach is dead cluster-wide**, on the cluster whose whole job is holding monitoring PVCs.

### The symptom is hard to read, hence the warning on the option

```
plain GET        -> 401          (so IMDS looks reachable)
hostNetwork pod  -> TOKEN-OK, role intra-node-role
ordinary pod     -> TOKEN-FAIL
SDK message      -> "no EC2 IMDS role found"   <- reads like IAM, is network
```

I chased this the wrong way twice before isolating it: busybox `wget` silently ignores `--method=PUT`, so my first three tests "failed" on every node including hostNetwork and pointed at a node-level problem. Re-running with curl gave the clean hostNetwork-works/pod-fails split.

### Notes

Default stays 2, so no existing template changes.

The value is in the template **hash** when set. AWSMachineTemplate specs are immutable, so a hop-limit change that did not rename the template would be silently never applied — the same class of silent no-op as the janitor's `--request-timeout`.

Not plumbed into `worker-fleet` yet: stage is still on Calico and will need it at the same time as everything else.