### PR TITLE
AwsK0sProvider: emit Cilium's transport as source-SG cniIngressRules

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -185,6 +185,13 @@ export function emitAwsClusterCr(
     ipv6?: boolean;
     /** CNI selected in the k0s ClusterConfig. Used to emit matching AWS SG rules. */
     networkProvider?: "kuberouter" | "calico" | "custom";
+    /**
+     * Which CNI's node-to-node transport to open, when `networkProvider` is
+     * "custom" and the CNI is installed separately. "cilium" emits its
+     * WireGuard port plus the cilium-health probes as SOURCE-SG rules, which
+     * is what makes them work on BOTH address families.
+     */
+    cni?: "cilium";
     /** Bundled Calico transport settings (only used when networkProvider="calico"). */
     calico?: ResolvedK0sCalico;
     /**
@@ -345,6 +352,43 @@ export function emitAwsClusterCr(
         // internet gateway from a public source, where these never match — such
         // a cluster must open the transport with CIDR-based
         // `additionalNodeIngressRules` instead.
+        //
+        // The same mechanism serves Cilium, and MUST: these rules are the only
+        // way to express "both address families inside this VPC". A CIDR-based
+        // rule carries `cidrBlocks` (v4) or `ipv6CidrBlocks` separately, and
+        // the VPC's IPv6 GUA is Amazon-assigned runtime state that has no place
+        // in git — so on a dual-stack cluster the v6 half silently stays shut.
+        // Observed on cicd: v4 4240 returned 200 while v6 4240 was refused, and
+        // cilium-health (which needs BOTH families per node) sat at 1/4.
+        ...(opts.cni === "cilium"
+          ? {
+              cni: {
+                cniIngressRules: [
+                  {
+                    description: "WireGuard (cilium)",
+                    protocol: "udp",
+                    fromPort: 51871,
+                    toPort: 51871,
+                  },
+                  // cilium-health probes each peer over HTTP on 4240 and ICMP.
+                  // Without these the datapath is fine and cluster health is
+                  // permanently yellow, which is worse than either extreme.
+                  {
+                    description: "cilium-health node probe",
+                    protocol: "tcp",
+                    fromPort: 4240,
+                    toPort: 4240,
+                  },
+                  {
+                    description: "cilium-health ICMP probe",
+                    protocol: "icmp",
+                    fromPort: -1,
+                    toPort: -1,
+                  },
+                ],
+              },
+            }
+          : {}),
         ...(opts.networkProvider === "calico"
           ? {
               cni: {

--- a/packages/nebula/src/modules/infra/aws/k0s-provider.ts
+++ b/packages/nebula/src/modules/infra/aws/k0s-provider.ts
@@ -96,6 +96,14 @@ export interface AwsK0sProviderConfig {
    * See the option of the same name in `_shared.ts` for the failure signature.
    */
   imdsHopLimit?: number;
+  /**
+   * Open a separately-installed CNI's node-to-node transport (use with
+   * `networkProvider: "custom"`). "cilium" emits WireGuard 51871 plus the
+   * cilium-health probes (tcp 4240 + ICMP) as SOURCE-SG rules, so they cover
+   * both address families — which CIDR-based rules cannot express, since the
+   * VPC's IPv6 GUA is runtime state.
+   */
+  cni?: "cilium";
 }
 
 /**
@@ -140,6 +148,7 @@ export class AwsK0sProvider implements K0sInfraProvider<AwsMachineSpec> {
           }),
       vpcCidr: this.config.vpcCidr ?? "10.0.0.0/16",
       networkProvider: ctx.networkProvider,
+      cni: this.config.cni,
       ipv6: this.config.ipv6,
       calico: ctx.calico,
       availabilityZoneUsageLimit: this.config.availabilityZoneUsageLimit,


### PR DESCRIPTION
CIDR-based `additionalNodeIngressRules` **cannot express "both address families inside this VPC"**. A rule carries `cidrBlocks` (v4) or `ipv6CidrBlocks` separately, and the VPC's IPv6 GUA is Amazon-assigned runtime state with no place in git — so on a dual-stack cluster the v6 half silently stays shut.

Observed on cicd:

```
v4 4240 -> HTTP 200
v6 4240 -> refused
cilium-health -> 1/4   (needs BOTH families healthy per node)
```

…while single-stack intra went straight to 3/3 off the identical config.

CAPA's `cniIngressRules` are **source-SG** rules — they match traffic from an ENI in the same security group, which is family-agnostic by construction. That is the mechanism Calico's transport already uses here; this just lets Cilium say the same thing.

`cni: "cilium"` emits:

```
udp  51871-51871  WireGuard (cilium)
tcp   4240-4240   cilium-health node probe
icmp    -1--1     cilium-health ICMP probe
```

Callers drop their hand-written CIDR rules. Renders nothing unless asked for, so no existing cluster changes.