### PR TITLE
Cilium cniIngressRules: ICMPv6 is protocol 58, not "icmp"

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -385,6 +385,19 @@ export function emitAwsClusterCr(
                     fromPort: -1,
                     toPort: -1,
                   },
+                  // ICMPv6 is a DIFFERENT AWS protocol (58), not a family of
+                  // "icmp" (1) — an icmp rule does not cover it. On a
+                  // dual-stack cluster that leaves exactly half the node probe
+                  // working: measured on cicd, HTTP 4240 answered 200 over both
+                  // families and ICMPv4 was 0% loss, while ICMPv6 was 100%
+                  // loss, holding every peer at Node 1/2 and cluster health at
+                  // 1/4. Harmless on single-stack, so it is emitted always.
+                  {
+                    description: "cilium-health ICMPv6 probe",
+                    protocol: "58",
+                    fromPort: -1,
+                    toPort: -1,
+                  },
                 ],
               },
             }


### PR DESCRIPTION
AWS treats ICMPv6 as its own protocol number (**58**). An `icmp` rule is IPv4 ICMP (protocol 1) and does **not** cover it, so on a dual-stack cluster exactly half the cilium-health node probe worked.

Measured on cicd after the source-SG rules landed:

```
HTTP 4240   v4 200, v6 200     <- fine, both families
ICMPv4      0% loss            <- the "icmp" rule works
ICMPv6      100% loss          <- nothing opened protocol 58
```

That held every peer at `Node 1/2` and cluster health at 1/4, while single-stack intra reported 3/3 off the same config.

**Two problems were stacked here.** The v4-only CIDR rules this replaced masked the second one as a CIDR problem — fixing that moved the probe from 0/2 to 1/2, which looked like partial progress toward a reconcile finishing, not a second distinct gap. It took probing each half of the check separately (curl for the HTTP half, ping for the ICMP half) to separate them.

Emitted unconditionally rather than gated on dual-stack: it is inert on a v4-only cluster, and the failure it prevents is silent.