### PR TITLE
Cilium + worker-fleet: the two things a cross-region fleet needs

### DIFF
--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -134,6 +134,11 @@ export interface AwsWorkerFleetOptions {
    * Cilium module for "cilium").
    */
   cni?: AwsWorkerFleetCni;
+  /**
+   * IMDSv2 `httpPutResponseHopLimit` for nodes with `imdsPodAccess` (default
+   * 2). Set 3 with `cni: "cilium"` — see the note at the render site.
+   */
+  imdsHopLimit?: number;
 }
 
 export type AwsWorkerFleetCni = "calico" | "cilium";
@@ -792,7 +797,16 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
           //     (ebs-csi) cannot obtain one at all.
           metadataOptions: [
             node.imdsPodAccess
-              ? { httpEndpoint: "enabled", httpTokens: "required", httpPutResponseHopLimit: 2 }
+              ? {
+                  httpEndpoint: "enabled",
+                  httpTokens: "required",
+                  // 2 covers a pod one veth away, which is what Calico gives.
+                  // CILIUM NEEDS 3 — its datapath adds a hop, and at 2 the
+                  // IMDSv2 token PUT fails for every pod-networked AWS
+                  // controller while a plain GET still returns 401 and
+                  // hostNetwork works fine, so it reads as an IAM fault.
+                  httpPutResponseHopLimit: this.options.imdsHopLimit ?? 2,
+                }
               : { httpEndpoint: "enabled", httpTokens: "optional", httpPutResponseHopLimit: 1 },
           ],
           blockDeviceMappings: [

--- a/packages/nebula/src/modules/k8s/cilium/index.ts
+++ b/packages/nebula/src/modules/k8s/cilium/index.ts
@@ -92,6 +92,19 @@ export interface CiliumConfig {
    *  node is being replaced). */
   operatorReplicas?: number;
   /**
+   * Connectivity health checking (defaults to true, as the chart does).
+   *
+   * Set FALSE where the probe cannot be made to work. cilium-health checks
+   * each peer with unauthenticated HTTP on 4240 plus ICMP, which on a fleet
+   * whose peers reach each other ACROSS THE PUBLIC INTERNET would mean opening
+   * both to 0.0.0.0/0 — and the node security-group posture there is that
+   * cryptographically authenticated protocols are open and unauthenticated
+   * ones are not exposed at all. Leaving the probe closed but enabled is the
+   * worst option: cluster health reads 1/N forever, and a permanently-yellow
+   * number is one nobody reads when it finally turns red.
+   */
+  healthChecking?: boolean;
+  /**
    * Hubble observability (defaults to FALSE — the chart defaults it on).
    *
    * Off because its auto-TLS generates `cilium-ca` and `hubble-server-certs`
@@ -176,6 +189,9 @@ export class Cilium extends HelmModule<CiliumConfig> {
           ? { operator: { replicas: this.config.operatorReplicas } }
           : {}),
 
+        ...(this.config.healthChecking === false
+          ? { healthChecking: false }
+          : {}),
         hubble: { enabled: hubble },
         envoy: { enabled: envoy },
 


### PR DESCRIPTION
Prerequisites for moving stage. Both default to today's behaviour, so no existing render changes.

### `healthChecking` on the Cilium module

cilium-health probes each peer with **unauthenticated** HTTP on 4240 plus ICMP. On a fleet whose peers reach each other across the **public internet**, that means opening both to `0.0.0.0/0` — and the worker-fleet security-group posture is explicit:

> cryptographically authenticated protocols are open and take no source list; unauthenticated ones are not exposed at all

Scoping to the peers is not available either: what git holds is EIP **allocation ids**, which are adoption handles, not addresses. The addresses are runtime state and deliberately absent.

So the probe cannot be made to work there, and leaving it enabled-but-blocked is the worst of the three options — cluster health reads 1/N forever, and a permanently-yellow number is one nobody reads when it finally turns red.

### `imdsHopLimit` on the worker fleet

It hardcoded 2. Same reason as the CAPA path in #124: Cilium's datapath adds a hop, so at 2 the IMDSv2 token PUT fails for every pod-networked AWS controller — while a plain GET still returns 401 and hostNetwork works fine, so it reads as an IAM fault. stage runs ebs-csi for its eu volumes and would lose volume attach/detach exactly as intra did.