### PR TITLE
dedupe DEFAULT_PRESTART_COMMANDS — the aws copy kept a retired stack alive

### DIFF
--- a/packages/nebula/src/modules/infra/aws/_shared.ts
+++ b/packages/nebula/src/modules/infra/aws/_shared.ts
@@ -111,15 +111,23 @@ export function toCapaB64(ini: string): string {
 }
 
 /**
- * Default cloud-init preStartCommands (storage deps for Piraeus/LINSTOR).
- * Shared by the workload-cluster worker config and the standalone
- * control-plane k0s config.
+ * Re-exported so this module keeps ONE source of truth with
+ * `modules/infra/k0s/cluster`.
+ *
+ * There used to be a second copy here, and it drifted: the k0s one was trimmed
+ * to just the inotify limits when Piraeus/LINSTOR were retired, while this one
+ * kept apt-installing linux-headers, thin-provisioning-tools, open-iscsi and
+ * cryptsetup — and enabling iscsid — on every node it rendered. Nothing in the
+ * estate has used a DRBD or iSCSI transport since; the only CSI drivers left
+ * are ebs.csi.aws.com and local.csi.openebs.io, and the LocalPV volume group
+ * is plain LVM with no thin pool. So those nodes paid an archive fetch and a
+ * kernel-header build at boot for a stack that was already gone.
+ *
+ * A pool that genuinely needs host storage packages asks via
+ * `extraPreStartCommands`, where the reason sits next to the cluster that has
+ * it.
  */
-export const DEFAULT_PRESTART_COMMANDS: readonly string[] = [
-  "sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=8192",
-  "apt-get update -qq && apt-get install -y -qq linux-headers-$(uname -r) lvm2 thin-provisioning-tools open-iscsi cryptsetup",
-  "systemctl enable --now iscsid || true",
-];
+export { DEFAULT_PRESTART_COMMANDS } from "../k0s/cluster";
 
 /**
  * Emit the CAPI `Cluster` CR. Identical across both AWS cluster modules except


### PR DESCRIPTION
There were **two** definitions and they drifted. `modules/infra/k0s/cluster` was trimmed to just the inotify limits when Piraeus/LINSTOR were retired, with a docstring explaining why. `modules/infra/aws/_shared` kept the original and was never touched — so every node it renders still installs:

```
linux-headers-$(uname -r)   thin-provisioning-tools   open-iscsi   cryptsetup
systemctl enable --now iscsid
```

Nothing has used a DRBD or iSCSI transport since. Verified live: the only CSI drivers across the estate are `ebs.csi.aws.com` and `local.csi.openebs.io`, no cluster references Piraeus/LINSTOR/Longhorn, and stage's LocalPV class is plain LVM (`volgroup: toolnode-vg`, no thin pool). Those nodes pay an archive fetch and a kernel-header build at **every boot** for a stack that was already gone — which also lengthens node replacement, an operation this estate performs constantly.

Re-exporting rather than re-trimming, so there is one source of truth and the copies cannot drift again.

## ⚠️ Blast radius — do not merge unsupervised

The surviving copy feeds `AwsK0sCluster`, which is **mgmt**. mgmt is a standalone `K0sControlPlane`, so a `k0sConfigSpec` change **rolls its three control-plane machines** — and mgmt is the substrate: CAPI, Crossplane, ArgoCD, and every workload cluster's hosted control plane. `mgmt-cluster-api` is auto-sync with `selfHeal`, so merging starts that roll immediately.

The repo already reserves this for a supervised maintenance window with a runbook, and it is a natural candidate to batch with other CP-spec changes.

**cicd, intra and stage are unaffected** — they render the already-clean copy.