### PR TITLE
mesh-scrape: target Cilium's cilium_host address, and publish it

### DIFF
--- a/packages/nebula/src/modules/k8s/cilium/index.ts
+++ b/packages/nebula/src/modules/k8s/cilium/index.ts
@@ -121,6 +121,24 @@ export interface CiliumConfig {
    * need their own opt-in; without them it is a per-node pod doing nothing.
    */
   envoy?: boolean;
+  /**
+   * Publish Cilium's node metadata as k8s Node annotations (defaults to TRUE;
+   * the chart defaults it off).
+   *
+   * `network.cilium.io/ipv{4,6}-cilium-host` is the only place a Prometheus
+   * scrape can learn the node's cilium_host address — the address lives on the
+   * CiliumNode CR, which service discovery cannot read. That address is what
+   * makes host-network exporters reachable at all where the node security group
+   * does not open their ports: it sits in the pod CIDR, so pod -> it is
+   * encapsulated and encrypted like any pod traffic. See the mesh-scrape
+   * module.
+   *
+   * The chart grants the matching `nodes/status: patch` RBAC itself. The
+   * annotation is written at agent bootstrap and the chart puts no config
+   * checksum on the DaemonSet, so flipping this does not backfill onto running
+   * agents — they have to be restarted.
+   */
+  annotateK8sNode?: boolean;
   /** Additional Helm values, deep-merged over the defaults above. */
   values?: Record<string, unknown>;
 }
@@ -183,6 +201,8 @@ export class Cilium extends HelmModule<CiliumConfig> {
         kubeProxyReplacement: this.config.kubeProxyReplacement
           ? "true"
           : "false",
+
+        annotateK8sNode: this.config.annotateK8sNode ?? true,
 
         ...(mtu ? { MTU: mtu } : {}),
         ...(this.config.operatorReplicas

--- a/packages/nebula/src/modules/k8s/index.ts
+++ b/packages/nebula/src/modules/k8s/index.ts
@@ -283,6 +283,8 @@ export {
 } from "./mesh-scrape";
 export type {
   MeshFamily,
+  MeshCni,
+  MeshTarget,
   MeshKubeProxyServiceMonitorOptions,
 } from "./mesh-scrape";
 export {

--- a/packages/nebula/src/modules/k8s/mesh-scrape/index.ts
+++ b/packages/nebula/src/modules/k8s/mesh-scrape/index.ts
@@ -1,45 +1,75 @@
 /**
- * Scrape host-network targets over the WireGuard mesh instead of the public
- * internet.
+ * Scrape host-network targets over the encrypted CNI mesh instead of the
+ * public internet.
  *
- * Calico gives each node a `wireguard.cali` / `wg-v6.cali` address from the
- * pod CIDR and publishes it on the Node object. An exporter bound to 0.0.0.0
- * in the host netns answers on it, and pod -> that address is tunnelled. So
- * retargeting the scrape there moves it onto the mesh — without moving the
- * exporter itself off the host network, which node_exporter does not support
- * (/proc/net is netns-scoped, so a pod-network exporter reports its own veth;
- * upstream closed this won't-fix and documents host network as the supported
- * configuration).
+ * Both supported CNIs give each node a host-netns address out of the pod CIDR.
+ * An exporter bound to 0.0.0.0 in the host netns answers on it, and pod -> that
+ * address is encapsulated and encrypted, so retargeting the scrape there moves
+ * it onto the mesh — without moving the exporter itself off the host network,
+ * which node_exporter does not support (/proc/net is netns-scoped, so a
+ * pod-network exporter reports its own veth; upstream closed this won't-fix and
+ * documents host network as the supported configuration).
+ *
+ * - Calico: the `wireguard.cali` / `wg-v6.cali` tunnel address, IPAM-allocated
+ *   per node per family.
+ * - Cilium: the `cilium_host` router address. NOT a tunnel address — it is
+ *   created by the agent at start rather than allocated, so the missing-address
+ *   failure class Calico has (edge-triggered allocator, no resync) is absent.
+ *   Reaching it needs no security-group rule the mesh does not already have:
+ *   the wire packet is the WireGuard UDP the peers already exchange.
+ *
+ * Cilium only publishes the address on the k8s Node when the agent is run with
+ * `annotateK8sNode: true` — nebula's Cilium module defaults it on for exactly
+ * this reason. The annotation is written at agent bootstrap, so enabling it
+ * does not backfill onto running agents.
  *
  * Requires `attachMetadata: { node: true }` on the monitor so node
  * annotations are available as relabel sources (Prometheus >= 2.37).
  *
- * Fail-visible by construction: a node whose WireGuard never came up has no
- * annotation, the regex does not match, `__address__` stays the discovered
- * address, and the scrape fails -> TargetDown. "WireGuard is broken on node
- * X" becomes an alert rather than a silent fallback to cleartext.
+ * Fail-visible by construction: a node with no annotation does not match the
+ * regex, `__address__` stays the discovered address, and the scrape fails ->
+ * TargetDown. "the mesh is broken on node X" becomes an alert rather than a
+ * silent fallback to cleartext.
  */
 import { Construct } from "constructs";
 import { ApiObject } from "cdk8s";
 
 export type MeshFamily = "IPv6" | "IPv4";
+export type MeshCni = "calico" | "cilium";
 
-const WG_ADDR_LABEL: Record<MeshFamily, string> = {
-  IPv6: "__meta_kubernetes_node_annotation_projectcalico_org_IPv6WireguardInterfaceAddr",
-  IPv4: "__meta_kubernetes_node_annotation_projectcalico_org_IPv4WireguardInterfaceAddr",
+/** Which node annotation carries the mesh address. */
+export interface MeshTarget {
+  /** Address family (defaults to IPv6). */
+  family?: MeshFamily;
+  /** CNI publishing the address (defaults to calico). */
+  cni?: MeshCni;
+}
+
+const MESH_ADDR_LABEL: Record<MeshCni, Record<MeshFamily, string>> = {
+  calico: {
+    IPv6: "__meta_kubernetes_node_annotation_projectcalico_org_IPv6WireguardInterfaceAddr",
+    IPv4: "__meta_kubernetes_node_annotation_projectcalico_org_IPv4WireguardInterfaceAddr",
+  },
+  cilium: {
+    IPv6: "__meta_kubernetes_node_annotation_network_cilium_io_ipv6_cilium_host",
+    IPv4: "__meta_kubernetes_node_annotation_network_cilium_io_ipv4_cilium_host",
+  },
 };
 
-/** Relabeling that retargets `__address__` onto the node's WireGuard mesh
- *  address (default the v6 tunnel; v6 literals are bracketed). */
-export const meshAddress = (port: number, family: MeshFamily = "IPv6") => [
-  {
-    action: "replace",
-    sourceLabels: [WG_ADDR_LABEL[family]],
-    regex: "(.+)",
-    replacement: family === "IPv6" ? `[$1]:${port}` : `$1:${port}`,
-    targetLabel: "__address__",
-  },
-];
+/** Relabeling that retargets `__address__` onto the node's mesh address
+ *  (default the Calico v6 tunnel; v6 literals are bracketed). */
+export const meshAddress = (port: number, target: MeshTarget = {}) => {
+  const family = target.family ?? "IPv6";
+  return [
+    {
+      action: "replace",
+      sourceLabels: [MESH_ADDR_LABEL[target.cni ?? "calico"][family]],
+      regex: "(.+)",
+      replacement: family === "IPv6" ? `[$1]:${port}` : `$1:${port}`,
+      targetLabel: "__address__",
+    },
+  ];
+};
 
 /** kube-prometheus-stack's kubelet ServiceMonitor relabels the metrics path
  *  onto a label; preserve that when overriding the endpoint's relabelings. */
@@ -56,30 +86,30 @@ export const KEEP_METRICS_PATH = {
  * is owned by {@link MeshKubeProxyServiceMonitor} instead.
  */
 export function meshMonitorValues(
-  family: MeshFamily = "IPv6",
+  target: MeshTarget = {},
 ): Record<string, unknown> {
   return {
     "prometheus-node-exporter": {
       prometheus: {
         monitor: {
           attachMetadata: { node: true },
-          relabelings: meshAddress(9100, family),
+          relabelings: meshAddress(9100, target),
         },
       },
     },
     kubelet: {
       serviceMonitor: {
         attachMetadata: { node: true },
-        relabelings: [KEEP_METRICS_PATH, ...meshAddress(10250, family)],
-        cAdvisorRelabelings: [KEEP_METRICS_PATH, ...meshAddress(10250, family)],
-        probesRelabelings: [KEEP_METRICS_PATH, ...meshAddress(10250, family)],
+        relabelings: [KEEP_METRICS_PATH, ...meshAddress(10250, target)],
+        cAdvisorRelabelings: [KEEP_METRICS_PATH, ...meshAddress(10250, target)],
+        probesRelabelings: [KEEP_METRICS_PATH, ...meshAddress(10250, target)],
       },
     },
     kubeProxy: { serviceMonitor: { enabled: false } },
   };
 }
 
-export interface MeshKubeProxyServiceMonitorOptions {
+export interface MeshKubeProxyServiceMonitorOptions extends MeshTarget {
   /** monitoring namespace the CR lands in. */
   namespace: string;
   /** metadata.name of the ServiceMonitor. */
@@ -87,7 +117,6 @@ export interface MeshKubeProxyServiceMonitorOptions {
   /** kube-prometheus-stack release name (the chart's Service carries it in
    *  its labels; default "prometheus"). */
   releaseName?: string;
-  family?: MeshFamily;
 }
 
 /**
@@ -122,7 +151,7 @@ export class MeshKubeProxyServiceMonitor extends Construct {
             port: "http-metrics",
             bearerTokenFile:
               "/var/run/secrets/kubernetes.io/serviceaccount/token",
-            relabelings: meshAddress(10249, options.family ?? "IPv6"),
+            relabelings: meshAddress(10249, options),
           },
         ],
       },


### PR DESCRIPTION
## Problem

`modules/k8s/mesh-scrape` relabels `__address__` from Calico's per-node WireGuard tunnel-address annotation. Cilium writes no such annotation, so on a Cilium cluster the `(.+)` regex misses, `__address__` keeps the discovered node IP, and every host-network exporter goes TargetDown — **46 of 76 active targets on stage** (kubelet 15, node-exporter 8, kube-proxy 8, NTH 8, lighthouse 6).

Not only a cross-region failure: measured pod → *same-region* node `10.8.2.106:9100` also times out. The node SG blocks these ports in every VPC.

## Fix

Cilium's equivalent of Calico's tunnel address is the **`cilium_host` router address** (`CiliumNode.spec.addresses[].CiliumInternalIP`) — host-netns, inside the pod CIDR, so a `0.0.0.0`-bound exporter answers on it and pod → it is VXLAN-encapsulated then WireGuard-encrypted.

Measured from a throwaway pod-network pod on `stage-eu-system-1`:

| from → to | result |
|---|---|
| eu → asia `10.244.4.226:9100` (v4) | **200** / 1.14s |
| eu → asia `[fd00::184e]:9100` (v6) | **200** / 1.14s |
| eu → asia `:5054` / `:10249` / `:10250` | **200** / **200** / **401** (answered, needs auth) |
| eu → na `10.244.7.78:9100` | **200** / 0.48s |
| eu → eu `10.244.15.76:9100` | **200** / 0.018s |
| eu → asia node IP / node GUA `:9100` | timeout 6s |
| eu → eu node IP `10.8.2.106:9100` | timeout 6s |

**No new security-group rule** — the wire packet is the WireGuard UDP/51871 the peers already exchange.

## Changes

- `mesh-scrape`: `MeshCni` (`calico` | `cilium`) and a `MeshTarget` options bag replacing the positional `family` argument; the Cilium map reads `network.cilium.io/ipv{4,6}-cilium-host`.
- `Cilium`: `annotateK8sNode` option, **defaulted on** (the chart defaults it off). Prometheus SD cannot read the CiliumNode CR, so the address has to reach the Node object; the chart ships the matching `nodes/status: patch` RBAC gated on the same value.

## Notes

- `meshAddress(port, family)` → `meshAddress(port, { family, cni })`. Only `DevOps aws/clusters/stage/monitoring` calls it; that side lands in the paired DevOps PR.
- The annotation is written at **agent bootstrap** and the chart puts no config checksum on the DaemonSet, so this does not backfill onto running agents — `rollout restart ds/cilium` is required. Documented on the option.
- Fail-visible is unchanged: no annotation → no match → TargetDown, never a silent fallback to cleartext.
- cicd/intra don't use mesh-scrape (single VPC); they only gain an unread annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)