### PR TITLE
cilium: expose the dataplane's own metrics, and Hubble without the churn

### DIFF
--- a/packages/nebula/src/modules/k8s/cilium/index.ts
+++ b/packages/nebula/src/modules/k8s/cilium/index.ts
@@ -105,16 +105,50 @@ export interface CiliumConfig {
    */
   healthChecking?: boolean;
   /**
+   * Prometheus metrics: agent on 9962, operator on 9963 (defaults to TRUE —
+   * the chart defaults the agent's endpoint off, which leaves the dataplane
+   * with no telemetry at all).
+   */
+  metrics?: boolean;
+  /**
+   * Chart-owned ServiceMonitor for the AGENT and for Hubble (defaults to true).
+   *
+   * Both are served by the hostNetwork agent, so where the node's ports are not
+   * reachable from the scraper the address has to be rewritten onto the mesh —
+   * and the chart's templates expose `relabelings` but not `attachMetadata`,
+   * without which the node annotation carrying that address is not a relabel
+   * source. Set false there and own the CRs with mesh-scrape's
+   * `MeshServiceMonitor`.
+   */
+  agentServiceMonitor?: boolean;
+  /** Chart-owned ServiceMonitor for the OPERATOR (defaults to true). It runs on
+   *  the pod network, so it never needs the mesh treatment. */
+  operatorServiceMonitor?: boolean;
+  /**
    * Hubble observability (defaults to FALSE — the chart defaults it on).
    *
-   * Off because its auto-TLS generates `cilium-ca` and `hubble-server-certs`
-   * with FRESH random material on every render. Under GitOps that is a
-   * rendered-manifest diff on every single sync: permanently OutOfSync, and
-   * every sync rotates the CA out from under the running agents. Turn it on
-   * only alongside `hubble.tls.auto.method: cronJob|certmanager`, or with
-   * certs supplied out of band.
+   * The chart's `helm` TLS method generates `cilium-ca` and
+   * `hubble-server-certs` with FRESH random material on every render: under
+   * GitOps that is a diff on every sync, permanently OutOfSync, and each sync
+   * rotates the CA out from under the running agents. {@link hubbleTlsMethod}
+   * therefore defaults to `cronJob` and does not offer `helm` at all.
    */
   hubble?: boolean;
+  /** Hubble metrics to export on 9965 (defaults to a flow/drop/dns/tcp set).
+   *  Empty disables the metrics server while leaving the observer on. */
+  hubbleMetrics?: string[];
+  /** hubble-relay, the cluster-wide flow aggregation API (defaults to false —
+   *  it is what `hubble observe` and the UI talk to, and neither is deployed
+   *  here; the metrics path does not need it). */
+  hubbleRelay?: boolean;
+  /** How Hubble's server certificates are produced (defaults to `cronJob`).
+   *  `helm` is not offered — see {@link hubble}. `certmanager` additionally
+   *  requires {@link hubbleTlsIssuerRef}; the chart fails the render without
+   *  it. */
+  hubbleTlsMethod?: "cronJob" | "certmanager";
+  /** Issuer for `hubbleTlsMethod: "certmanager"`, e.g.
+   *  `{ name: "cilium-ca", kind: "Issuer", group: "cert-manager.io" }`. */
+  hubbleTlsIssuerRef?: Record<string, unknown>;
   /**
    * Run Envoy as its own DaemonSet (defaults to FALSE — the chart defaults it
    * on). It exists for L7 policy, ingress and TLS interception, all of which
@@ -154,6 +188,14 @@ export class Cilium extends HelmModule<CiliumConfig> {
     const mtu = this.config.mtu;
     const hubble = this.config.hubble ?? false;
     const envoy = this.config.envoy ?? false;
+    const metrics = this.config.metrics ?? true;
+    const agentServiceMonitor =
+      metrics && (this.config.agentServiceMonitor ?? true);
+    const operatorServiceMonitor =
+      metrics && (this.config.operatorServiceMonitor ?? true);
+    const hubbleMetrics =
+      this.config.hubbleMetrics ??
+      (hubble ? ["dns", "drop", "tcp", "flow", "port-distribution", "icmp"] : []);
 
     // Fail closed on a sub-1280 MTU. This is not a preference: Linux removes
     // IPv6 from any interface below the v6 minimum, so the kernel strips it
@@ -205,14 +247,55 @@ export class Cilium extends HelmModule<CiliumConfig> {
         annotateK8sNode: this.config.annotateK8sNode ?? true,
 
         ...(mtu ? { MTU: mtu } : {}),
-        ...(this.config.operatorReplicas
-          ? { operator: { replicas: this.config.operatorReplicas } }
-          : {}),
 
         ...(this.config.healthChecking === false
           ? { healthChecking: false }
           : {}),
-        hubble: { enabled: hubble },
+
+        // `trustCRDsExist` is not optimism — the chart's validate.yaml does an
+        // API lookup for the ServiceMonitor CRD and hard-fails the render when
+        // it cannot reach a cluster, which is every GitOps render. It reads the
+        // AGENT's copy of the flag no matter which monitor tripped the check,
+        // so it is set unconditionally: gating it on the agent monitor breaks
+        // exactly the config that turns the agent monitor off and keeps the
+        // operator's.
+        prometheus: {
+          enabled: metrics,
+          serviceMonitor: { enabled: agentServiceMonitor, trustCRDsExist: true },
+        },
+        operator: {
+          ...(this.config.operatorReplicas
+            ? { replicas: this.config.operatorReplicas }
+            : {}),
+          prometheus: {
+            enabled: metrics,
+            serviceMonitor: { enabled: operatorServiceMonitor },
+          },
+        },
+
+        hubble: {
+          enabled: hubble,
+          relay: { enabled: this.config.hubbleRelay ?? false },
+          ...(hubble
+            ? {
+                tls: {
+                  auto: {
+                    method: this.config.hubbleTlsMethod ?? "cronJob",
+                    ...(this.config.hubbleTlsIssuerRef
+                      ? { certManagerIssuerRef: this.config.hubbleTlsIssuerRef }
+                      : {}),
+                  },
+                },
+                metrics: {
+                  enabled: hubbleMetrics,
+                  serviceMonitor: {
+                    enabled: agentServiceMonitor && hubbleMetrics.length > 0,
+                    trustCRDsExist: true,
+                  },
+                },
+              }
+            : {}),
+        },
         envoy: { enabled: envoy },
 
         // With Envoy off there is no TLS interception, so the chart's dedicated

--- a/packages/nebula/src/modules/k8s/index.ts
+++ b/packages/nebula/src/modules/k8s/index.ts
@@ -279,12 +279,15 @@ export {
   meshAddress,
   meshMonitorValues,
   KEEP_METRICS_PATH,
+  NODE_FROM_POD,
+  MeshServiceMonitor,
   MeshKubeProxyServiceMonitor,
 } from "./mesh-scrape";
 export type {
   MeshFamily,
   MeshCni,
   MeshTarget,
+  MeshServiceMonitorOptions,
   MeshKubeProxyServiceMonitorOptions,
 } from "./mesh-scrape";
 export {

--- a/packages/nebula/src/modules/k8s/mesh-scrape/index.ts
+++ b/packages/nebula/src/modules/k8s/mesh-scrape/index.ts
@@ -109,6 +109,90 @@ export function meshMonitorValues(
   };
 }
 
+export interface MeshServiceMonitorOptions extends MeshTarget {
+  /** Namespace the CR lands in. */
+  namespace: string;
+  /** metadata.name of the ServiceMonitor. */
+  name: string;
+  /** Labels selecting the Service whose endpoints are the host-network pods. */
+  selector: Record<string, string>;
+  /** Namespaces to search for that Service (default: the CR's own). */
+  serviceNamespaces?: string[];
+  /** Endpoint port NAME on the Service. */
+  port: string;
+  /** Port the exporter listens on in the host netns — what the mesh address is
+   *  rewritten to. Usually the Service's targetPort, not its port. */
+  targetPort: number;
+  path?: string;
+  scheme?: string;
+  interval?: string;
+  honorLabels?: boolean;
+  bearerTokenFile?: string;
+  jobLabel?: string;
+  targetLabels?: string[];
+  /** Relabelings applied BEFORE the address rewrite. */
+  relabelings?: unknown[];
+}
+
+/**
+ * A ServiceMonitor for a host-network exporter, scraped at the node's mesh
+ * address.
+ *
+ * Exists because `attachMetadata` is what makes node annotations available as
+ * relabel sources, and almost no upstream chart exposes it — kube-prometheus-
+ * stack's kube-proxy template and Cilium's own agent/Hubble templates all offer
+ * `relabelings` but not `attachMetadata`, which makes their monitors unusable
+ * here. Disable the chart's monitor and own the CR with this instead.
+ */
+export class MeshServiceMonitor extends Construct {
+  constructor(
+    scope: Construct,
+    id: string,
+    options: MeshServiceMonitorOptions,
+  ) {
+    super(scope, id);
+    new ApiObject(this, "servicemonitor", {
+      apiVersion: "monitoring.coreos.com/v1",
+      kind: "ServiceMonitor",
+      metadata: { name: options.name, namespace: options.namespace },
+      spec: {
+        ...(options.jobLabel ? { jobLabel: options.jobLabel } : {}),
+        ...(options.targetLabels ? { targetLabels: options.targetLabels } : {}),
+        namespaceSelector: {
+          matchNames: options.serviceNamespaces ?? [options.namespace],
+        },
+        selector: { matchLabels: options.selector },
+        attachMetadata: { node: true },
+        endpoints: [
+          {
+            port: options.port,
+            ...(options.path ? { path: options.path } : {}),
+            ...(options.scheme ? { scheme: options.scheme } : {}),
+            ...(options.interval ? { interval: options.interval } : {}),
+            ...(options.honorLabels ? { honorLabels: true } : {}),
+            ...(options.bearerTokenFile
+              ? { bearerTokenFile: options.bearerTokenFile }
+              : {}),
+            relabelings: [
+              ...(options.relabelings ?? []),
+              ...meshAddress(options.targetPort, options),
+            ],
+          },
+        ],
+      },
+    });
+  }
+}
+
+/** Copy the pod's node name onto a `node` label — what Cilium's own chart
+ *  monitors do, and what its dashboards select on. */
+export const NODE_FROM_POD = {
+  action: "replace",
+  replacement: "${1}",
+  sourceLabels: ["__meta_kubernetes_pod_node_name"],
+  targetLabel: "node",
+};
+
 export interface MeshKubeProxyServiceMonitorOptions extends MeshTarget {
   /** monitoring namespace the CR lands in. */
   namespace: string;


### PR DESCRIPTION
## Problem

Nothing scrapes Cilium anywhere in the fleet. Verified on stage: `prometheus-serve-addr` is unset in `cilium-config` and `kubectl -n kube-system get svc` returns no `cilium-agent`, `cilium-operator` or `hubble-*` Service. The module set no prometheus values at all, so cicd and intra are the same. The estate moved its dataplane to Cilium and kept zero telemetry on it.

## Changes

**`Cilium`**
- `metrics` (default **true**) — agent 9962, operator 9963. The chart defaults the agent's endpoint off.
- `agentServiceMonitor` / `operatorServiceMonitor` (both default true). Two switches because the components differ in kind: the operator is pod-network and scrapes anywhere; the agent is hostNetwork and where node ports are closed its address must be rewritten onto the mesh — which the chart's template cannot express (`relabelings` but no `attachMetadata`). Setting `agentServiceMonitor: false` keeps the Service so a `MeshServiceMonitor` can select it.
- `hubble` + `hubbleMetrics` / `hubbleRelay` / `hubbleTlsMethod` / `hubbleTlsIssuerRef`. Still off by default, but now safe to enable: the reason it was banned was the chart's `helm` TLS method minting a fresh CA on every render, so the type **does not offer `helm`** and the method defaults to `cronJob`.

**`mesh-scrape`** — `MeshServiceMonitor`, generalising `MeshKubeProxyServiceMonitor`. Three consumers now (kube-proxy, cilium-agent, hubble), all for the same reason: no upstream chart exposes `attachMetadata`. Plus `NODE_FROM_POD`, the `__meta_kubernetes_pod_node_name` → `node` relabeling Cilium's own monitors apply and its dashboards select on.

## Two things worth flagging

**`trustCRDsExist` is set unconditionally**, not alongside the agent monitor. The chart's `validate.yaml` reads `.Values.prometheus.serviceMonitor.trustCRDsExist` no matter which of the four monitors tripped the CRD check, so gating it on the agent monitor fails the render in exactly the configuration that disables the agent monitor and keeps the operator's. Caught while rendering stage's shape, not in review.

**Hubble renders deterministically** — rendered twice, byte-identical. The generated cert Job passes `--ca-reuse-secret` and its name carries a values hash, and there are no `helm.sh/hook` annotations, so it is a plain immutable Job under GitOps.

## Verified

Rendered four configurations against the real chart (1.20.0):

| config | ServiceMonitors |
|---|---|
| default | `cilium-agent`, `cilium-operator` |
| stage (`agentServiceMonitor: false`) | `cilium-operator` only — agent Service still present |
| hubble on | `cilium-agent`, `cilium-operator`, `hubble` + cert `Job`/`CronJob` |
| `metrics: false` | none |

Enabling metrics adds a container port to the agent DaemonSet, so it triggers a rolling agent restart on each cluster when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)