### PR TITLE
cilium: metricsService, or turning the chart's monitor off removes the port

### DIFF
--- a/packages/nebula/src/modules/k8s/cilium/index.ts
+++ b/packages/nebula/src/modules/k8s/cilium/index.ts
@@ -259,8 +259,16 @@ export class Cilium extends HelmModule<CiliumConfig> {
         // so it is set unconditionally: gating it on the agent monitor breaks
         // exactly the config that turns the agent monitor off and keeps the
         // operator's.
+        //
+        // `metricsService` is what renders the Service that carries the
+        // `metrics` port. The chart gates that Service on
+        // `serviceMonitor.enabled OR metricsService`, so turning the chart's
+        // monitor off to own it elsewhere also removes the port the owned
+        // monitor selects — the agent Service survives with only
+        // `envoy-metrics` on it and the replacement monitor matches nothing.
         prometheus: {
           enabled: metrics,
+          metricsService: metrics,
           serviceMonitor: { enabled: agentServiceMonitor, trustCRDsExist: true },
         },
         operator: {
@@ -269,6 +277,7 @@ export class Cilium extends HelmModule<CiliumConfig> {
             : {}),
           prometheus: {
             enabled: metrics,
+            metricsService: metrics,
             serviceMonitor: { enabled: operatorServiceMonitor },
           },
         },


### PR DESCRIPTION
Follow-up to #132, caught rendering the DevOps side rather than in review.

The chart gates the `cilium-agent` Service on `serviceMonitor.enabled OR metricsService`. So `agentServiceMonitor: false` — the whole point of which is to own the monitor elsewhere — also drops the `metrics` port from the Service. What is left is a `cilium-agent` Service carrying only `envoy-metrics`, and the replacement monitor selecting `port: metrics` matches nothing. Same gate on the operator's Service.

`metricsService` is the chart's own answer: render the Service without the ServiceMonitor. Set it to follow `metrics` on both components; when the chart monitor is also on the condition is an OR, so nothing changes there.

Verified: with `agentServiceMonitor: false` the agent Service now carries `metrics` 9962 (targetPort `prometheus`) alongside `envoy-metrics`, and no `cilium-agent` ServiceMonitor is emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)