### PR TITLE
cilium: the operator is hostNetwork too — correct the operatorServiceMonitor doc

### DIFF
--- a/packages/nebula/src/modules/k8s/cilium/index.ts
+++ b/packages/nebula/src/modules/k8s/cilium/index.ts
@@ -121,8 +121,15 @@ export interface CiliumConfig {
    * `MeshServiceMonitor`.
    */
   agentServiceMonitor?: boolean;
-  /** Chart-owned ServiceMonitor for the OPERATOR (defaults to true). It runs on
-   *  the pod network, so it never needs the mesh treatment. */
+  /**
+   * Chart-owned ServiceMonitor for the OPERATOR (defaults to true).
+   *
+   * The operator is hostNetwork too (`operator.hostNetwork` is a chart default,
+   * so it can reach the API server before the CNI is up), which means its 9963
+   * is behind the same closed node port as the agent's 9962 and it needs the
+   * same treatment. Measured, not assumed: with the chart's monitor only the
+   * replica sharing a node with Prometheus came up.
+   */
   operatorServiceMonitor?: boolean;
   /**
    * Hubble observability (defaults to FALSE — the chart defaults it on).


### PR DESCRIPTION
The option's docstring claimed the operator runs on the pod network and so never needs the mesh treatment. It does not: `operator.hostNetwork` is a chart default (the operator has to reach the API server before the CNI is up), so its 9963 sits behind the same closed node port as the agent's 9962.

Measured after rolling all three clusters — with the chart's monitor, only the replica sharing a node with Prometheus came up:

```
up    cilium-operator  http://10.3.203.125:9963/metrics
down  cilium-operator  http://10.3.183.65:9963/metrics   context deadline exceeded
```

No behaviour change — the switch already existed — but the doc was steering callers into a broken configuration. The DevOps side flips `operatorServiceMonitor: false` and meshes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)