### PR TITLE
cilium: drop port-distribution from the default Hubble metrics

### DIFF
--- a/packages/nebula/src/modules/k8s/cilium/index.ts
+++ b/packages/nebula/src/modules/k8s/cilium/index.ts
@@ -142,7 +142,10 @@ export interface CiliumConfig {
    */
   hubble?: boolean;
   /** Hubble metrics to export on 9965 (defaults to a flow/drop/dns/tcp set).
-   *  Empty disables the metrics server while leaving the observer on. */
+   *  Empty disables the metrics server while leaving the observer on.
+   *  `port-distribution` is deliberately NOT in the default: it labels by
+   *  port, so any node talking to the internet (P2P, crawlers) mints a series
+   *  per peer port and grows without bound. */
   hubbleMetrics?: string[];
   /** hubble-relay, the cluster-wide flow aggregation API (defaults to false —
    *  it is what `hubble observe` and the UI talk to, and neither is deployed
@@ -201,8 +204,7 @@ export class Cilium extends HelmModule<CiliumConfig> {
     const operatorServiceMonitor =
       metrics && (this.config.operatorServiceMonitor ?? true);
     const hubbleMetrics =
-      this.config.hubbleMetrics ??
-      (hubble ? ["dns", "drop", "tcp", "flow", "port-distribution", "icmp"] : []);
+      this.config.hubbleMetrics ?? (hubble ? ["dns", "drop", "tcp", "flow", "icmp"] : []);
 
     // Fail closed on a sub-1280 MTU. This is not a preference: Linux removes
     // IPv6 from any interface below the v6 minimum, so the kernel strips it

--- a/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
+++ b/packages/nebula/src/modules/k8s/prometheus-operator/index.ts
@@ -785,9 +785,11 @@ export class PrometheusOperator extends HelmModule<PrometheusOperatorConfig> {
           },
           // Bitnami's default resourcesPreset ("micro", 192Mi) is far too small
           // for the fan-out merge under real dashboard load; give query room.
+          // 2Gi, not 1Gi: at ~1M series across the hub's stores, 1Gi OOMs on
+          // startup fan-out and query-frontend's retries re-kill each new pod.
           resources: {
             requests: { cpu: "100m", memory: "256Mi" },
-            limits: { memory: "1Gi" },
+            limits: { memory: "2Gi" },
           },
         },
         queryFrontend: { enabled: true, tolerations: defaultTolerations },


### PR DESCRIPTION
## What

Remove `port-distribution` from nebula's default `hubbleMetrics` set, and raise `thanos-query`'s memory limit from 1Gi to 2Gi.

## Why

`hubble_port_distribution_total` carries a `port` label, so every peer port a node observes mints a new series. On nodes carrying internet-facing P2P that is unbounded.

Measured on the live fleet ~9h after Hubble was enabled:

| stage node | series |
|---|---|
| stage-asia-1 | 25,110 |
| stage-na-2 | 23,709 |
| stage-na-1 | 23,165 |
| stage-asia-2 | 22,950 |
| stage-eu-tool-1 | 19,352 |
| stage-eu-mainnet-2 | 10,814 |
| stage-eu-system-1 | 18 |
| stage-eu-system-2 | 15 |

The system nodes — which only talk to the cluster — sit at 15-18. The Ethereum tool/mainnet nodes sit at 19k-25k because each remote peer's ephemeral port becomes a series. Fleet-wide growth was ~7,600 series/hour and not converging; it had become the largest single metric on the intra hub at 162,739 series.

`dns`, `drop`, `tcp` and `flow` are bounded by workload identity rather than by peer, so the default keeps them. `port-distribution` remains available via explicit `hubbleMetrics` for clusters with no internet-facing P2P.

## thanos-query 2Gi

Bundled here because this is the failure that surfaced the cardinality. At ~1M series across the hub's stores, the 1Gi limit OOM-kills `thanos-query` during startup fan-out; `query-frontend` then retries five times with no backoff and re-kills each replacement pod ~78s in. The result is a self-sustaining crashloop that takes Grafana's Thanos datasource down with it. 2Gi matches what `storegateway` and `compactor` already carry for the same class of reason.

## Test

- `tsc --noEmit` clean
- `cdk8s synth` on the AWS example renders no `port-distribution`

🤖 Generated with [Claude Code](https://claude.com/claude-code)