### PR TITLE
aws/worker-fleet: let a spot node launch as more than one instance type

### DIFF
--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -190,6 +190,13 @@ export interface AwsWorkerFleetNode {
   allocationId?: string;
   rootVolumeGi?: number;
   spot?: boolean;
+  /** Extra instance types this node may launch as, beyond {@link instanceType}.
+   *  Spot capacity is per (type, AZ) pool, so a single-type node rides one
+   *  pool and dies whenever that pool drains — the AZ cannot be diversified
+   *  here because a data volume is AZ-bound, which leaves the type as the only
+   *  axis. Renders a MixedInstancesPolicy over the same LaunchTemplate;
+   *  requires {@link spot} (on-demand has no allocation strategy to pick). */
+  altInstanceTypes?: string[];
   /** IMDS hop limit 2: pods on this node may use the node role (keyless AWS
    *  controllers). System nodes only. */
   imdsPodAccess?: boolean;
@@ -810,6 +817,13 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
   ) {
     const o = this.options;
     const p = this.prefix(region);
+    // Diversification is spot-only: instancesDistribution is the sole way to
+    // ask for spot under a MixedInstancesPolicy, so an on-demand node with
+    // altInstanceTypes would silently become spot. Ignore it instead.
+    const mixedTypes =
+      node.spot && node.altInstanceTypes?.length
+        ? [node.instanceType, ...node.altInstanceTypes]
+        : undefined;
     new ApiObject(this, `${node.name}-launch-template`, {
       apiVersion: "ec2.aws.upbound.io/v1beta1",
       kind: "LaunchTemplate",
@@ -881,7 +895,12 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
               ],
             },
           ],
-          ...(node.spot
+          // A MixedInstancesPolicy carries the spot request itself, and AWS
+          // REJECTS a launch template that also sets instanceMarketOptions
+          // ("incompatible with the mixed instances policy"). Diversified
+          // nodes therefore leave it off; instancesDistribution below is what
+          // makes them spot.
+          ...(node.spot && !mixedTypes
             ? { instanceMarketOptions: [{ marketType: "spot" }] }
             : {}),
           userData: Buffer.from(this.userData(node, region)).toString("base64"),
@@ -919,7 +938,34 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
           healthCheckType: "EC2",
           // never block reconcile on capacity (spot may wait for a pool).
           waitForCapacityTimeout: "0",
-          launchTemplate: [{ name: node.name, version: "$Latest" }],
+          ...(mixedTypes
+            ? {
+                mixedInstancesPolicy: [
+                  {
+                    launchTemplate: [
+                      {
+                        launchTemplateSpecification: [
+                          { launchTemplateName: node.name, version: "$Latest" },
+                        ],
+                        override: mixedTypes.map((instanceType) => ({ instanceType })),
+                      },
+                    ],
+                    // 100% spot above a zero on-demand base — the plain
+                    // instanceMarketOptions this replaces, restated.
+                    // price-capacity-optimized, not lowest-price: it weighs
+                    // pool depth as well as price, which is the whole point
+                    // of listing more than one type.
+                    instancesDistribution: [
+                      {
+                        onDemandBaseCapacity: 0,
+                        onDemandPercentageAboveBaseCapacity: 0,
+                        spotAllocationStrategy: "price-capacity-optimized",
+                      },
+                    ],
+                  },
+                ],
+              }
+            : { launchTemplate: [{ name: node.name, version: "$Latest" }] }),
           vpcZoneIdentifierRefs: [
             { name: `${p}-subnet`, policy: { resolve: "Always", resolution: "Required" } },
           ],


### PR DESCRIPTION
## Why

Spot capacity is per **(instance type, AZ)** pool. A node pinned to one type rides one pool and dies when that pool drains.

Observed on `stage-eu-mainnet-1` this morning — five `m6a.2xlarge` instances, every one an AWS-initiated reclaim, lifetimes collapsing:

```
i-04850de36c0d4e85f  09:17 → 10:36   79 min
i-026a4d996217c9acf  10:37 → 11:13   36 min
i-0dc5fe405d6a77315  11:13 → 11:24   11 min
i-0d3f4e0258b75faa7  11:25 → 11:33    8 min
```

The AZ can't be the axis: these nodes carry an EBS data volume and EBS is AZ-bound. That leaves the instance type — and AWS's placement scores say it's enough. In `euc1-az2`, target capacity 1:

| type | score |
|---|---|
| m6a.2xlarge | 3 |
| m6i.2xlarge | 1 |
| m5.2xlarge | 1 |
| m5a.2xlarge | 3 |
| m7i.2xlarge | 3 |
| m7a.2xlarge | 3 |
| **all six pooled** | **9** |

## What

`altInstanceTypes?: string[]` on `AwsWorkerFleetNode`. When set on a spot node, the ASG renders a `MixedInstancesPolicy` over the same LaunchTemplate instead of a plain `launchTemplate` ref.

Two traps encoded:

- **The LaunchTemplate must not also set `instanceMarketOptions`.** AWS rejects a template requesting spot under a mixed instances policy. Diversified nodes drop it; `instancesDistribution` (`onDemandBaseCapacity: 0`, `onDemandPercentageAboveBaseCapacity: 0`) is what makes them spot.
- **`price-capacity-optimized`, not the `lowest-price` default.** It weighs pool depth as well as price, which is the whole point of listing more than one type.

Spot-only by construction: `instancesDistribution` is the only way to request spot under the policy, so honouring `altInstanceTypes` on an on-demand node would silently convert it to spot. It's ignored there instead.

## Test

`tsc --noEmit` clean. Synthesized a diversified node next to a plain one:

```yaml
### LaunchTemplate / mixed
    instanceType: m6a.2xlarge          # no instanceMarketOptions
### AutoscalingGroup / mixed
    mixedInstancesPolicy:
          - onDemandBaseCapacity: 0
            onDemandPercentageAboveBaseCapacity: 0
            spotAllocationStrategy: price-capacity-optimized
        launchTemplate:
          - launchTemplateSpecification:
              - launchTemplateName: mixed
                version: $Latest
            override:
              - instanceType: m6a.2xlarge
              - instanceType: m6i.2xlarge
              - instanceType: m5.2xlarge

### LaunchTemplate / plain
    instanceMarketOptions:
      - marketType: spot               # unchanged
    instanceType: m6a.2xlarge
### AutoscalingGroup / plain
    launchTemplate:                    # unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)