### PR TITLE
aws/worker-fleet: clear instanceMarketOptions, don't just omit it

### DIFF
--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -897,12 +897,21 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
           ],
           // A MixedInstancesPolicy carries the spot request itself, and AWS
           // REJECTS a launch template that also sets instanceMarketOptions
-          // ("incompatible with the mixed instances policy"). Diversified
-          // nodes therefore leave it off; instancesDistribution below is what
-          // makes them spot.
-          ...(node.spot && !mixedTypes
-            ? { instanceMarketOptions: [{ marketType: "spot" }] }
-            : {}),
+          // ("Incompatible launch template ... Add a different launch template
+          // to the group"). instancesDistribution below is what makes a
+          // diversified node spot.
+          //   The empty list is deliberate and must not be simplified to
+          // omitting the key. This MR runs with LateInitialize, so an absent
+          // field is merely unmanaged: Crossplane writes the observed spot
+          // marketType straight back into spec and the ASG update keeps
+          // failing (observed live on both stage eu mainnet nodes). Clearing
+          // it requires STATING the empty value — same lesson as the IMDS
+          // block below.
+          ...(mixedTypes
+            ? { instanceMarketOptions: [] }
+            : node.spot
+              ? { instanceMarketOptions: [{ marketType: "spot" }] }
+              : {}),
           userData: Buffer.from(this.userData(node, region)).toString("base64"),
           tagSpecifications: [
             {


### PR DESCRIPTION
Follow-up to #136, which shipped an incomplete fix.

#136 dropped `instanceMarketOptions` from the launch template for diversified nodes. That isn't enough: the LaunchTemplate MR runs with `LateInitialize`, so an **absent** field is unmanaged rather than empty. Crossplane writes the observed `marketType: spot` back into spec, the template keeps requesting spot, and the ASG update fails on every reconcile:

```
InvalidQueryParameter: Incompatible launch template: You cannot use a
launch template that is set to request Spot Instances (InstanceMarketOptions)
when you configure an Auto Scaling group with a mixed instances policy.
Add a different launch template to the group and try again.
```

Observed live on both `stage-eu-mainnet-1` and `-2` immediately after #136 shipped. Failure was benign — both ASGs stayed `Ready` on their previous config — but the mixed instances policy never applied, so the diversification did nothing.

Live confirmation that omitting doesn't clear:

```
stage-eu-mainnet-1:  spec={"marketType":"spot"}  atProvider={"marketType":"spot",...}
stage-eu-tool-1:     spec=ABSENT                 atProvider={}
```

The on-demand node shows late-init won't *invent* the field from an empty observation — but the spot nodes' observation is non-empty, so it gets written back.

**Fix:** state the empty list. Same lesson the IMDS block a few lines below already carries — removing a field from git only stops managing it; correcting AWS requires saying what you want.

Scoped to diversified nodes: on-demand and single-type spot nodes render exactly as before, so this causes no fleet-wide launch-template version churn.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)