### PR TITLE
aws/worker-fleet: a diversified node gets its own launch template

### DIFF
--- a/packages/nebula/src/modules/infra/aws/worker-fleet.ts
+++ b/packages/nebula/src/modules/infra/aws/worker-fleet.ts
@@ -824,10 +824,24 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
       node.spot && node.altInstanceTypes?.length
         ? [node.instanceType, ...node.altInstanceTypes]
         : undefined;
+    // A diversified node gets its OWN launch template, never the plain-spot
+    // one it may be converted from. AWS says as much in the rejection it
+    // raises otherwise ("Add a different launch template to the group"), but
+    // the reason to obey it here is the provider: this MR late-initializes,
+    // and upjet reports instanceMarketOptions.marketType=spot on a template
+    // whose live default version has NO market options at all (verified
+    // against the AWS API — not lag; a forced re-observe reports the same).
+    // So on a converted template the field cannot be cleared and stay
+    // cleared: omitting it lets late-init put spot back, and rendering the
+    // empty list that does clear it is a zero-value the stored object drops,
+    // which is a diff that never closes and a resync every 5 minutes forever.
+    // A fresh name sidesteps the whole thing — nothing to observe, nothing to
+    // late-initialize, nothing to clear.
+    const ltName = mixedTypes ? `${node.name}-mixed` : node.name;
     new ApiObject(this, `${node.name}-launch-template`, {
       apiVersion: "ec2.aws.upbound.io/v1beta1",
       kind: "LaunchTemplate",
-      metadata: { name: node.name },
+      metadata: { name: ltName },
       spec: {
         deletionPolicy: "Delete",
         // Update IS on here (unlike the Instance MR): LT updates are
@@ -840,7 +854,7 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
         managementPolicies: ["Observe", "Create", "Update", "Delete", "LateInitialize"],
         forProvider: {
           region: region.region,
-          name: node.name,
+          name: ltName,
           imageId: node.ami,
           instanceType: node.instanceType,
           updateDefaultVersion: true,
@@ -896,22 +910,13 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
             },
           ],
           // A MixedInstancesPolicy carries the spot request itself, and AWS
-          // REJECTS a launch template that also sets instanceMarketOptions
-          // ("Incompatible launch template ... Add a different launch template
-          // to the group"). instancesDistribution below is what makes a
-          // diversified node spot.
-          //   The empty list is deliberate and must not be simplified to
-          // omitting the key. This MR runs with LateInitialize, so an absent
-          // field is merely unmanaged: Crossplane writes the observed spot
-          // marketType straight back into spec and the ASG update keeps
-          // failing (observed live on both stage eu mainnet nodes). Clearing
-          // it requires STATING the empty value — same lesson as the IMDS
-          // block below.
-          ...(mixedTypes
-            ? { instanceMarketOptions: [] }
-            : node.spot
-              ? { instanceMarketOptions: [{ marketType: "spot" }] }
-              : {}),
+          // rejects a launch template that also sets instanceMarketOptions.
+          // Safe to simply omit here BECAUSE a diversified node is on its own
+          // template (see ltName): there is no inherited spot value for
+          // late-initialization to restore.
+          ...(node.spot && !mixedTypes
+            ? { instanceMarketOptions: [{ marketType: "spot" }] }
+            : {}),
           userData: Buffer.from(this.userData(node, region)).toString("base64"),
           tagSpecifications: [
             {
@@ -954,7 +959,7 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
                     launchTemplate: [
                       {
                         launchTemplateSpecification: [
-                          { launchTemplateName: node.name, version: "$Latest" },
+                          { launchTemplateName: ltName, version: "$Latest" },
                         ],
                         override: mixedTypes.map((instanceType) => ({ instanceType })),
                       },
@@ -974,7 +979,7 @@ ${vol ? `until aws ec2 attach-volume --region ${r} --instance-id "$IID" --volume
                   },
                 ],
               }
-            : { launchTemplate: [{ name: node.name, version: "$Latest" }] }),
+            : { launchTemplate: [{ name: ltName, version: "$Latest" }] }),
           vpcZoneIdentifierRefs: [
             { name: `${p}-subnet`, policy: { resolve: "Always", resolution: "Required" } },
           ],


### PR DESCRIPTION
Third and final follow-up on the spot diversification (#136, #137).

## The dead end

#137 cleared `instanceMarketOptions` by rendering the **empty list**. It works — AWS version 5 is clean and both ASGs took their mixed instances policy — but it cannot settle. The empty array is a zero-value the stored object drops, so `desired []` vs `live absent` is a diff that never closes. `cluster-stage` sat permanently OutOfSync and resynced every 5 minutes (13:09:56, 13:14:57, ...), re-running the CMP each time.

Omitting the field is worse. The MR late-initializes, and upjet reports a market option that **does not exist at AWS**:

```
atProvider:  latestVersion=5  defaultVersion=5  market={"marketType":"spot"}
AWS API:     version 5 is Default and Latest, InstanceMarketOptions = null
```

A forced re-observe returns the same, so it's a provider quirk, not a stale cache. An omitted field gets refilled with spot and the ASG update starts failing again — exactly what happened after #136.

`ignoreDifferences` doesn't rescue it either: these apps carry `RespectIgnoreDifferences=true`, so ignored fields are taken from live during sync and the empty list would stop being asserted at all — identical to omitting.

## The fix

Both dead ends are trying to unpick a value the template inherited from its single-type past. So don't inherit it. A diversified node now builds `<name>-mixed`, a template that never requested spot: nothing to observe, nothing to late-initialize, nothing to clear, and the field is simply omitted as it already is for on-demand nodes.

AWS suggests precisely this in the rejection it raises — *"Add a different launch template to the group and try again."*

## Rendered

| node | launch template | market options | ASG |
|---|---|---|---|
| diversified | `<name>-mixed` | omitted | `mixedInstancesPolicy` |
| plain spot | `<name>` | `marketType: spot` | plain `launchTemplate` |
| on-demand | `<name>` | omitted | plain `launchTemplate` |

Plain-spot and on-demand render byte-identically to before. `tsc --noEmit` clean.

## Note for the consuming repo

Converting an existing node leaves its old LaunchTemplate MR out of the desired state. Under the `capi` preset that isn't pruned, so it needs a one-time delete — **after** the ASG has repointed, since deleting the MR deletes the AWS template.

> Committed unsigned: the signing YubiKey was unplugged mid-session and an on-card key can't be cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)